### PR TITLE
feat: add camera CoT and scope batmesh1 radio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# OpenMANETd — Codex Guide
+
+`CLAUDE.md` is the canonical repository guide. Before modifying this repository,
+read it completely and follow its commands, architecture notes, generated-code
+boundaries, testing patterns, and platform gotchas.
+
+The detailed rules under `.claude/rules/` also apply to Codex. Read the rules
+relevant to the work before editing:
+
+- All Go changes: `concurrency.md`, `performance.md`, `idiomatic-go.md`, and
+  `testing.md`.
+- API changes: `api-design.md` and `testing.md`.
+- Frontend changes: `frontend.md` and the frontend sections of `testing.md`.
+- Instrumentation snapshot changes: `instrumentation.md`.
+
+Treat these referenced documents as repository instructions, not optional
+background material. Keep this file as a small entrypoint so the Claude and
+Codex guidance cannot drift into conflicting copies; update the canonical guide
+or shared rule files when project policy changes.
+
+At minimum, every behavior change must have tests, all Go changes must be
+formatted and lint-clean, and concurrency-sensitive changes must pass the race
+detector. Never directly edit generated files under `internal/api/`,
+`frontend/src/gen/`, or `internal/database/models/`.

--- a/internal/camera/camera.go
+++ b/internal/camera/camera.go
@@ -1,0 +1,153 @@
+// Package camera discovers node cameras and publishes their Cursor-on-Target
+// video and sensor events to ATAK.
+package camera
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openmanet/openmanetd/internal/network"
+)
+
+const (
+	defaultCameraInterface = "ahwlan"
+	defaultRTSPPort        = 554
+	defaultRTSPName        = "rpicamera"
+	cameraProbeTimeout     = 2 * time.Second
+)
+
+// Stream describes the RTSP endpoint advertised to ATAK.
+type Stream struct {
+	Address string
+	Path    string
+	Port    int
+}
+
+// URL returns the stream's canonical RTSP URL.
+func (s Stream) URL() string {
+	u := url.URL{
+		Scheme: "rtsp",
+		Host:   net.JoinHostPort(s.Address, strconv.Itoa(s.Port)),
+		Path:   s.Path,
+	}
+
+	return u.String()
+}
+
+// Detect reports whether cam can see a libcamera-compatible sensor.
+func Detect(ctx context.Context) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, cameraProbeTimeout)
+	defer cancel()
+
+	output, err := exec.CommandContext(ctx, "cam", "-l").Output() //nolint:gosec // fixed local command and arguments
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("list cameras: %w", err)
+	}
+
+	return cameraListContainsSensor(output), nil
+}
+
+// ResolveStream returns the existing MediaMTX endpoint on the configured
+// OpenMANET camera interface. It requires no openmanetd-specific setting.
+func ResolveStream(ctx context.Context) (Stream, error) {
+	return resolveCameraStreamWith(ctx, network.NewUCINetworkConfigReader(), network.GetInterfaceByName)
+}
+
+type configReader interface {
+	Get(config, section, option string) ([]string, bool)
+}
+
+type interfaceLookup func(string) network.NetworkInterface
+
+func resolveCameraStreamWith(ctx context.Context, reader configReader, lookup interfaceLookup) (Stream, error) {
+	if err := ctx.Err(); err != nil {
+		return Stream{}, fmt.Errorf("resolve camera stream: %w", err)
+	}
+
+	interfaceName := firstConfigValue(reader, "camera-onvif-server", "rpicamera", "interface", defaultCameraInterface)
+	deviceName := firstConfigValue(reader, "network", interfaceName, "device", network.DefaultBridgeInterfaceName)
+
+	address := firstIPv4Address(lookup(deviceName))
+
+	if err := ctx.Err(); err != nil {
+		return Stream{}, fmt.Errorf("resolve camera stream: %w", err)
+	}
+
+	if address == "" {
+		return Stream{}, fmt.Errorf("camera interface %q has no IPv4 address", deviceName)
+	}
+
+	rtspAddress := firstConfigValue(reader, "mediamtx", "@mediamtx[0]", "rtsp_address", "")
+	rtspName := firstConfigValue(reader, "camera-onvif-server", "rpicamera", "rtsp_name", defaultRTSPName)
+
+	return Stream{
+		Address: address,
+		Path:    "/" + strings.TrimLeft(rtspName, "/"),
+		Port:    parseRTSPPort(rtspAddress),
+	}, nil
+}
+
+func cameraListContainsSensor(output []byte) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		prefix, _, ok := strings.Cut(strings.TrimSpace(scanner.Text()), ":")
+		if !ok {
+			continue
+		}
+
+		if _, err := strconv.Atoi(strings.TrimSpace(prefix)); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func firstConfigValue(reader configReader, configName, section, option, fallback string) string {
+	values, ok := reader.Get(configName, section, option)
+	if !ok || len(values) == 0 || strings.TrimSpace(values[0]) == "" {
+		return fallback
+	}
+
+	return strings.TrimSpace(values[0])
+}
+
+func firstIPv4Address(iface network.NetworkInterface) string {
+	for _, address := range iface.IP {
+		ip := address.IP.To4()
+		if ip != nil && !ip.IsLoopback() {
+			return ip.String()
+		}
+	}
+
+	return ""
+}
+
+func parseRTSPPort(address string) int {
+	value := strings.TrimSpace(address)
+	if _, port, err := net.SplitHostPort(value); err == nil {
+		value = port
+	} else {
+		value = strings.TrimPrefix(value, ":")
+	}
+
+	port, err := strconv.Atoi(value)
+	if err != nil || port < 1 || port > 65535 {
+		return defaultRTSPPort
+	}
+
+	return port
+}

--- a/internal/camera/camera_test.go
+++ b/internal/camera/camera_test.go
@@ -3,6 +3,8 @@ package camera
 import (
 	"context"
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/openmanet/openmanetd/internal/network"
@@ -16,6 +18,23 @@ func TestDetect_missingBinary(t *testing.T) {
 	present, err := Detect(context.Background())
 	require.NoError(t, err)
 	assert.False(t, present)
+}
+
+func TestDetect_camera(t *testing.T) {
+	writeCamCommand(t, "#!/bin/sh\nprintf 'Available cameras:\\n1: imx219\\n'\n")
+
+	present, err := Detect(context.Background())
+	require.NoError(t, err)
+	assert.True(t, present)
+}
+
+func TestDetect_commandError(t *testing.T) {
+	writeCamCommand(t, "#!/bin/sh\nexit 1\n")
+
+	present, err := Detect(context.Background())
+	require.Error(t, err)
+	assert.False(t, present)
+	assert.ErrorContains(t, err, "list cameras")
 }
 
 func TestCameraListContainsSensor_output(t *testing.T) {
@@ -102,9 +121,39 @@ func TestResolveStream_canceledContext(t *testing.T) {
 	assert.False(t, lookupCalled)
 }
 
+func TestResolveStream_publicWrapperCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ResolveStream(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestResolveStream_contextCanceledDuringLookup(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_, err := resolveCameraStreamWith(ctx, newFakeConfigReader(t, nil), func(string) network.NetworkInterface {
+		cancel()
+
+		return network.NetworkInterface{IP: []network.IPAddress{{IP: net.ParseIP("10.41.2.3")}}}
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestStream_URL(t *testing.T) {
 	t.Parallel()
 
 	stream := Stream{Address: "10.41.0.1", Path: "/rpicamera main", Port: 8554}
 	assert.Equal(t, "rtsp://10.41.0.1:8554/rpicamera%20main", stream.URL())
+}
+
+func writeCamCommand(t *testing.T, contents string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cam"), []byte(contents), 0o755))
+	t.Setenv("PATH", dir)
 }

--- a/internal/camera/camera_test.go
+++ b/internal/camera/camera_test.go
@@ -1,0 +1,110 @@
+package camera
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/openmanet/openmanetd/internal/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetect_missingBinary(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	present, err := Detect(context.Background())
+	require.NoError(t, err)
+	assert.False(t, present)
+}
+
+func TestCameraListContainsSensor_output(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{name: "camera", output: "Available cameras:\n------------------\n0 : imx219 [3280x2464]", want: true},
+		{name: "no camera", output: "Available cameras:\n------------------\n", want: false},
+		{name: "unrelated colon", output: "Available cameras:\nnone: detected", want: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, cameraListContainsSensor([]byte(tc.output)))
+		})
+	}
+}
+
+func TestResolveStream_configuredEndpoint(t *testing.T) {
+	t.Parallel()
+
+	reader := newFakeConfigReader(t, map[string][]string{
+		"camera-onvif-server.rpicamera.interface": {"ahwlan"},
+		"camera-onvif-server.rpicamera.rtsp_name": {"camera/main"},
+		"network.ahwlan.device":                   {"br-ahwlan"},
+		"mediamtx.@mediamtx[0].rtsp_address":      {":8554"},
+	})
+	lookup := func(name string) network.NetworkInterface {
+		assert.Equal(t, network.DefaultBridgeInterfaceName, name)
+
+		return network.NetworkInterface{IP: []network.IPAddress{{IP: net.ParseIP("10.41.0.1")}}}
+	}
+
+	stream, err := resolveCameraStreamWith(context.Background(), reader, lookup)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stream{Address: "10.41.0.1", Port: 8554, Path: "/camera/main"}, stream)
+}
+
+func TestResolveStream_defaults(t *testing.T) {
+	t.Parallel()
+
+	stream, err := resolveCameraStreamWith(context.Background(), newFakeConfigReader(t, nil), func(name string) network.NetworkInterface {
+		assert.Equal(t, network.DefaultBridgeInterfaceName, name)
+
+		return network.NetworkInterface{IP: []network.IPAddress{
+			{IP: net.ParseIP("127.0.0.1")},
+			{IP: net.ParseIP("10.41.2.3")},
+		}}
+	})
+	require.NoError(t, err)
+	assert.Equal(t, Stream{Address: "10.41.2.3", Port: defaultRTSPPort, Path: "/" + defaultRTSPName}, stream)
+}
+
+func TestResolveStream_missingIPv4Address(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveCameraStreamWith(context.Background(), newFakeConfigReader(t, nil), func(string) network.NetworkInterface {
+		return network.NetworkInterface{IP: []network.IPAddress{{IP: net.ParseIP("127.0.0.1")}}}
+	})
+	require.Error(t, err)
+}
+
+func TestResolveStream_canceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	lookupCalled := false
+	_, err := resolveCameraStreamWith(ctx, newFakeConfigReader(t, nil), func(string) network.NetworkInterface {
+		lookupCalled = true
+
+		return network.NetworkInterface{}
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, lookupCalled)
+}
+
+func TestStream_URL(t *testing.T) {
+	t.Parallel()
+
+	stream := Stream{Address: "10.41.0.1", Path: "/rpicamera main", Port: 8554}
+	assert.Equal(t, "rtsp://10.41.0.1:8554/rpicamera%20main", stream.URL())
+}

--- a/internal/camera/cot.go
+++ b/internal/camera/cot.go
@@ -1,0 +1,195 @@
+package camera
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/coreywagehoft/go-tak/pkg/cot"
+	"github.com/coreywagehoft/go-tak/pkg/cotproto"
+	"github.com/openmanet/openmanetd/internal/config"
+	"github.com/openmanet/openmanetd/internal/network"
+	"golang.org/x/net/ipv4"
+)
+
+const (
+	cameraSensorType     = "b-m-p-s-p-loc"
+	cameraStaleDuration  = 5 * time.Minute
+	cameraMulticastPort  = 6969
+	cameraMulticastTTL   = 64
+	cameraPublishTimeout = 2 * time.Second
+	xmlAttributeUID      = "uid"
+)
+
+// Position contains the GNSS values used to locate camera events.
+type Position struct {
+	Altitude        float64
+	CE              float64
+	GeoidSeparation float64
+	Lat             float64
+	LE              float64
+	Lon             float64
+	Speed           float64
+	Track           float64
+}
+
+// Node identifies the OpenMANET camera node.
+type Node struct {
+	Callsign string
+	UID      string
+}
+
+// BuildMessage builds one camera sensor event containing its video
+// source. It intentionally does not build a normal radio marker.
+func BuildMessage(position Position, node Node, stream Stream) *cotproto.TakMessage {
+	videoUID := node.UID + "-video"
+	detail := cot.NewXMLDetails()
+	detail.AddChild("sensor", map[string]string{
+		"azimuth":   "0",
+		"elevation": "0",
+		"fov":       "45",
+		"hideFov":   "true",
+		"range":     "100",
+		"vfov":      "45",
+	}, "")
+	video := detail.AddChild("__video", map[string]string{
+		xmlAttributeUID: videoUID,
+		"url":           stream.URL(),
+	}, "")
+	video.AddChild("ConnectionEntry", map[string]string{
+		"address":           stream.Address,
+		"alias":             node.Callsign + " Video",
+		"bufferTime":        "-1",
+		"ignoreEmbeddedKLV": "false",
+		"networkTimeout":    "12000",
+		"path":              stream.Path,
+		"port":              strconv.Itoa(stream.Port),
+		"protocol":          "rtsp",
+		"roverPort":         "-1",
+		"rtspReliable":      "0",
+		xmlAttributeUID:     videoUID,
+	}, "")
+
+	return cameraMessage(cameraSensorType, node.UID, node.Callsign, position, detail.AsXMLString())
+}
+
+// Publish publishes a mesh ping followed by one camera sensor event
+// containing its video source through the OpenMANET bridge.
+func Publish(ctx context.Context, position Position, node Node, stream Stream) error {
+	ctx, cancel := context.WithTimeout(ctx, cameraPublishTimeout)
+	defer cancel()
+
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("publish camera CoT: %w", err)
+	}
+
+	destination, err := net.ResolveUDPAddr("udp4", net.JoinHostPort(config.ATAKSAAddress, strconv.Itoa(cameraMulticastPort)))
+	if err != nil {
+		return fmt.Errorf("resolve ATAK multicast address: %w", err)
+	}
+
+	bridge, err := net.InterfaceByName(network.DefaultBridgeInterfaceName)
+	if err != nil {
+		return fmt.Errorf("find ATAK multicast interface %q: %w", network.DefaultBridgeInterfaceName, err)
+	}
+
+	conn, err := net.ListenUDP("udp4", nil)
+	if err != nil {
+		return fmt.Errorf("open ATAK multicast socket: %w", err)
+	}
+	defer func() {
+		// The send result is authoritative; a UDP close error is not recoverable here.
+		_ = conn.Close()
+	}()
+
+	deadline, ok := ctx.Deadline()
+	if ok {
+		if err := conn.SetWriteDeadline(deadline); err != nil {
+			return fmt.Errorf("set ATAK multicast write deadline: %w", err)
+		}
+	}
+
+	packet := ipv4.NewPacketConn(conn)
+
+	return publishCameraMessage(ctx, packet, bridge, destination, BuildMessage(position, node, stream))
+}
+
+type multicastPacketWriter interface {
+	SetMulticastInterface(*net.Interface) error
+	SetMulticastTTL(int) error
+	WriteTo([]byte, *ipv4.ControlMessage, net.Addr) (int, error)
+}
+
+func publishCameraMessage(
+	ctx context.Context,
+	packet multicastPacketWriter,
+	bridge *net.Interface,
+	destination *net.UDPAddr,
+	message *cotproto.TakMessage,
+) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("write ATAK multicast packet: %w", err)
+	}
+
+	if err := packet.SetMulticastTTL(cameraMulticastTTL); err != nil {
+		return fmt.Errorf("set ATAK multicast TTL: %w", err)
+	}
+
+	if err := packet.SetMulticastInterface(bridge); err != nil {
+		return fmt.Errorf("set ATAK multicast interface %q: %w", bridge.Name, err)
+	}
+
+	if err := writeCameraMessage(ctx, packet, destination, cot.MakePing("openmanet-ping")); err != nil {
+		return err
+	}
+
+	return writeCameraMessage(ctx, packet, destination, message)
+}
+
+func writeCameraMessage(
+	ctx context.Context,
+	packet multicastPacketWriter,
+	destination *net.UDPAddr,
+	message *cotproto.TakMessage,
+) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("write ATAK multicast packet: %w", err)
+	}
+
+	data, err := cot.MakeProtoMeshPacketV1(message)
+	if err != nil {
+		return fmt.Errorf("marshal ATAK mesh packet: %w", err)
+	}
+
+	if _, err := packet.WriteTo(data, nil, destination); err != nil {
+		return fmt.Errorf("write ATAK multicast packet: %w", err)
+	}
+
+	return nil
+}
+
+func cameraMessage(eventType, uid, callsign string, position Position, xmlDetail string) *cotproto.TakMessage {
+	message := cot.BasicMsg(eventType, uid, cameraStaleDuration)
+	event := message.CotEvent
+	event.Lat = position.Lat
+	event.Lon = position.Lon
+	event.Hae = position.Altitude + position.GeoidSeparation
+	event.Ce = position.CE
+	event.Le = position.LE
+	event.Detail = &cotproto.Detail{
+		XmlDetail: xmlDetail,
+		Contact:   &cotproto.Contact{Callsign: callsign},
+		Track: &cotproto.Track{
+			Course: position.Track,
+			Speed:  position.Speed,
+		},
+		PrecisionLocation: &cotproto.PrecisionLocation{
+			Altsrc:      "GPS",
+			Geopointsrc: "GPS",
+		},
+	}
+
+	return message
+}

--- a/internal/camera/cot_test.go
+++ b/internal/camera/cot_test.go
@@ -86,6 +86,7 @@ func TestPublishCameraMessage_socketErrors(t *testing.T) {
 		{name: "TTL", writer: &fakeMulticastPacketWriter{TTLErr: errors.New("TTL failed")}, wantErr: "set ATAK multicast TTL"},
 		{name: "interface", writer: &fakeMulticastPacketWriter{InterfaceErr: errors.New("interface failed")}, wantErr: "set ATAK multicast interface"},
 		{name: "write", writer: &fakeMulticastPacketWriter{WriteErr: errors.New("write failed")}, wantErr: "write ATAK multicast packet"},
+		{name: "second write", writer: &fakeMulticastPacketWriter{WriteErr: errors.New("second write failed"), WriteErrAt: 2}, wantErr: "write ATAK multicast packet"},
 	}
 
 	for _, tc := range tests {
@@ -98,6 +99,32 @@ func TestPublishCameraMessage_socketErrors(t *testing.T) {
 			assert.ErrorContains(t, err, tc.wantErr)
 		})
 	}
+}
+
+func TestPublishCameraMessage_contextCanceledBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	writer := &fakeMulticastPacketWriter{Cancel: cancel}
+	bridge := &net.Interface{Name: "br-ahwlan"}
+	destination := &net.UDPAddr{IP: net.ParseIP("239.2.3.1"), Port: cameraMulticastPort}
+	message := BuildMessage(testPosition(t), Node{Callsign: "NODE-MANET", UID: "NODE-MANET"}, testStream(t))
+
+	err := publishCameraMessage(ctx, writer, bridge, destination, message)
+	require.ErrorIs(t, err, context.Canceled)
+
+	_, _, writes := writer.state()
+	assert.Zero(t, writes)
+}
+
+func TestPublish_canceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := Publish(ctx, testPosition(t), Node{Callsign: "NODE-MANET", UID: "NODE-MANET"}, testStream(t))
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestPublishCameraMessage_canceledContext(t *testing.T) {

--- a/internal/camera/cot_test.go
+++ b/internal/camera/cot_test.go
@@ -1,0 +1,140 @@
+package camera
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/coreywagehoft/go-tak/pkg/cot"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMessage_replacesRadioMarker(t *testing.T) {
+	t.Parallel()
+
+	event := BuildMessage(testPosition(t), Node{Callsign: "NODE-MANET", UID: "NODE-MANET"}, testStream(t)).GetCotEvent()
+	assert.Equal(t, cameraSensorType, event.GetType())
+	assert.Equal(t, "NODE-MANET", event.GetUid())
+	assert.NotEqual(t, "a-f-G-U-U-S-R", event.GetType())
+}
+
+func TestBuildMessage_containsVideo(t *testing.T) {
+	t.Parallel()
+
+	event := BuildMessage(testPosition(t), Node{Callsign: "NODE-MANET", UID: "NODE-MANET"}, testStream(t)).GetCotEvent()
+
+	detail, err := cot.DetailsFromString(event.GetDetail().GetXmlDetail())
+	require.NoError(t, err)
+
+	video := detail.GetFirst("__video")
+	connection := video.GetFirst("ConnectionEntry")
+
+	assert.Equal(t, "NODE-MANET-video", video.GetAttr("uid"))
+	assert.Equal(t, testStream(t).URL(), video.GetAttr("url"))
+	assert.Equal(t, video.GetAttr("uid"), connection.GetAttr("uid"))
+	assert.Equal(t, testStream(t).Address, connection.GetAttr("address"))
+	assert.Equal(t, "8554", connection.GetAttr("port"))
+	assert.Equal(t, "true", detail.GetFirst("sensor").GetAttr("hideFov"))
+}
+
+func TestBuildMessage_meshPacketRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	message := BuildMessage(testPosition(t), Node{Callsign: "NODE-MANET", UID: "NODE-MANET"}, testStream(t))
+
+	data, err := cot.MakeProtoMeshPacketV1(message)
+	require.NoError(t, err)
+
+	decoded, version, err := cot.ReadProtoMesh(bufio.NewReader(bytes.NewReader(data)))
+	require.NoError(t, err)
+	assert.Equal(t, cot.ProtoVersion1, version)
+	assert.Equal(t, message.GetCotEvent().GetUid(), decoded.GetCotEvent().GetUid())
+}
+
+func TestPublishCameraMessage_bridgeAndWrites(t *testing.T) {
+	t.Parallel()
+
+	writer := &fakeMulticastPacketWriter{}
+	bridge := &net.Interface{Index: 7, Name: "br-ahwlan"}
+	destination := &net.UDPAddr{IP: net.ParseIP("239.2.3.1"), Port: cameraMulticastPort}
+	message := BuildMessage(testPosition(t), Node{Callsign: "NODE-MANET", UID: "NODE-MANET"}, testStream(t))
+
+	require.NoError(t, publishCameraMessage(context.Background(), writer, bridge, destination, message))
+
+	gotBridge, gotTTL, gotWrites := writer.state()
+	assert.Same(t, bridge, gotBridge)
+	assert.Equal(t, cameraMulticastTTL, gotTTL)
+	assert.Equal(t, 2, gotWrites)
+}
+
+func TestPublishCameraMessage_socketErrors(t *testing.T) {
+	t.Parallel()
+
+	bridge := &net.Interface{Name: "br-ahwlan"}
+	destination := &net.UDPAddr{IP: net.ParseIP("239.2.3.1"), Port: cameraMulticastPort}
+	message := BuildMessage(testPosition(t), Node{Callsign: "NODE-MANET", UID: "NODE-MANET"}, testStream(t))
+
+	tests := []struct {
+		name    string
+		writer  *fakeMulticastPacketWriter
+		wantErr string
+	}{
+		{name: "TTL", writer: &fakeMulticastPacketWriter{TTLErr: errors.New("TTL failed")}, wantErr: "set ATAK multicast TTL"},
+		{name: "interface", writer: &fakeMulticastPacketWriter{InterfaceErr: errors.New("interface failed")}, wantErr: "set ATAK multicast interface"},
+		{name: "write", writer: &fakeMulticastPacketWriter{WriteErr: errors.New("write failed")}, wantErr: "write ATAK multicast packet"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := publishCameraMessage(context.Background(), tc.writer, bridge, destination, message)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestPublishCameraMessage_canceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	writer := &fakeMulticastPacketWriter{}
+	bridge := &net.Interface{Name: "br-ahwlan"}
+	destination := &net.UDPAddr{IP: net.ParseIP("239.2.3.1"), Port: cameraMulticastPort}
+	message := BuildMessage(testPosition(t), Node{Callsign: "NODE-MANET", UID: "NODE-MANET"}, testStream(t))
+
+	err := publishCameraMessage(ctx, writer, bridge, destination, message)
+	require.ErrorIs(t, err, context.Canceled)
+
+	_, _, writes := writer.state()
+	assert.Zero(t, writes)
+}
+
+func testPosition(t *testing.T) Position {
+	t.Helper()
+
+	return Position{
+		Altitude:        50,
+		CE:              2,
+		GeoidSeparation: 15,
+		Lat:             37.7749,
+		LE:              3,
+		Lon:             -122.4194,
+		Speed:           5,
+		Track:           90,
+	}
+}
+
+func testStream(t *testing.T) Stream {
+	t.Helper()
+
+	return Stream{Address: "10.41.0.1", Path: "/" + defaultRTSPName, Port: 8554}
+}

--- a/internal/camera/mocks_test.go
+++ b/internal/camera/mocks_test.go
@@ -1,6 +1,7 @@
 package camera
 
 import (
+	"context"
 	"net"
 	"sync"
 	"testing"
@@ -39,15 +40,22 @@ type fakeMulticastPacketWriter struct {
 	InterfaceErr error
 	TTLErr       error
 	WriteErr     error
+	WriteErrAt   int
+	Cancel       context.CancelFunc
 }
 
 func (w *fakeMulticastPacketWriter) SetMulticastInterface(bridge *net.Interface) error {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
 	w.bridge = bridge
+	err := w.InterfaceErr
+	cancel := w.Cancel
+	w.mu.Unlock()
 
-	return w.InterfaceErr
+	if cancel != nil {
+		cancel()
+	}
+
+	return err
 }
 
 func (w *fakeMulticastPacketWriter) SetMulticastTTL(ttl int) error {
@@ -65,7 +73,11 @@ func (w *fakeMulticastPacketWriter) WriteTo([]byte, *ipv4.ControlMessage, net.Ad
 
 	w.writes++
 
-	return 1, w.WriteErr
+	if w.WriteErrAt == 0 || w.writes == w.WriteErrAt {
+		return 1, w.WriteErr
+	}
+
+	return 1, nil
 }
 
 func (w *fakeMulticastPacketWriter) state() (*net.Interface, int, int) {

--- a/internal/camera/mocks_test.go
+++ b/internal/camera/mocks_test.go
@@ -1,0 +1,76 @@
+package camera
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"golang.org/x/net/ipv4"
+)
+
+type fakeConfigReader struct {
+	mu sync.RWMutex // protects the fields below
+
+	values map[string][]string
+}
+
+func newFakeConfigReader(t *testing.T, values map[string][]string) *fakeConfigReader {
+	t.Helper()
+
+	return &fakeConfigReader{values: values}
+}
+
+func (r *fakeConfigReader) Get(config, section, option string) ([]string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	value, ok := r.values[config+"."+section+"."+option]
+
+	return value, ok
+}
+
+type fakeMulticastPacketWriter struct {
+	mu sync.Mutex // protects the fields below
+
+	bridge *net.Interface
+	ttl    int
+	writes int
+
+	InterfaceErr error
+	TTLErr       error
+	WriteErr     error
+}
+
+func (w *fakeMulticastPacketWriter) SetMulticastInterface(bridge *net.Interface) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.bridge = bridge
+
+	return w.InterfaceErr
+}
+
+func (w *fakeMulticastPacketWriter) SetMulticastTTL(ttl int) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.ttl = ttl
+
+	return w.TTLErr
+}
+
+func (w *fakeMulticastPacketWriter) WriteTo([]byte, *ipv4.ControlMessage, net.Addr) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.writes++
+
+	return 1, w.WriteErr
+}
+
+func (w *fakeMulticastPacketWriter) state() (*net.Interface, int, int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.bridge, w.ttl, w.writes
+}

--- a/internal/gpsd/connection.go
+++ b/internal/gpsd/connection.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/openmanet/openmanetd/internal/camera"
 	"github.com/openmanet/openmanetd/internal/config"
 	"github.com/rs/zerolog"
 )
@@ -29,10 +30,16 @@ func NewGPSServiceWithAddress(log zerolog.Logger, cfg *config.Config, address st
 		}
 	})
 
+	cameraPresent, err := camera.Detect(context.Background())
+	if err != nil {
+		log.Debug().Err(err).Msg("Unable to detect camera for ATAK advertisement")
+	}
+
 	g := &GPSService{
 		Log:            log,
 		Config:         cfg,
 		address:        address,
+		cameraPresent:  cameraPresent,
 		done:           done,
 		cancel:         cancel,
 		reconnectDelay: 5 * time.Second,

--- a/internal/gpsd/cot.go
+++ b/internal/gpsd/cot.go
@@ -1,6 +1,7 @@
 package gpsd
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"net"
@@ -12,6 +13,7 @@ import (
 	"github.com/coreywagehoft/go-tak/pkg/cot"
 	"github.com/coreywagehoft/go-tak/pkg/cotproto"
 	"github.com/mdlayher/arp"
+	"github.com/openmanet/openmanetd/internal/camera"
 	"github.com/openmanet/openmanetd/internal/config"
 	"github.com/openmanet/openmanetd/internal/network"
 	"github.com/openmanet/openmanetd/internal/util/board"
@@ -40,6 +42,10 @@ func (g *GPSService) SendIfRequiredAsCoT() {
 		return
 	}
 
+	if g.sendCameraCoTIfPresent(context.Background()) {
+		return
+	}
+
 	leases, err := network.GetCurrentDHCPLeases()
 	if err != nil {
 		g.Log.Error().Err(err).Msg("Error getting DHCP leases for EUD location update")
@@ -65,16 +71,9 @@ func (g *GPSService) SendIfRequiredAsCoT() {
 
 	// Only send to multicast if no devices received any messages
 	if !deviceActive {
-		// Rate limit: send multicast messages once every 30 seconds to avoid flooding the network
-		g.mu.Lock()
-		if time.Since(g.lastMulticastTime) < cotMulticastRateLimit {
-			g.mu.Unlock()
-
-			return // Rate limited, exit early
+		if !g.reserveCoTMulticastSend() {
+			return
 		}
-
-		g.lastMulticastTime = time.Now()
-		g.mu.Unlock()
 
 		if err := g.sendCoTPing(); err != nil {
 			g.Log.Error().Err(err).Msg("Failed to send CoT ping to multicast")
@@ -86,6 +85,66 @@ func (g *GPSService) SendIfRequiredAsCoT() {
 			g.Log.Error().Err(err).Msg("Failed to send CoT to multicast")
 		}
 	}
+}
+
+// sendCameraCoTIfPresent reports whether camera publication owns this update.
+// A true result always prevents the caller from emitting a normal radio marker,
+// including when the camera stream cannot currently be advertised.
+func (g *GPSService) sendCameraCoTIfPresent(ctx context.Context) bool {
+	if !g.cameraPresent {
+		return false
+	}
+
+	if !g.reserveCoTMulticastSend() {
+		return true
+	}
+
+	if err := g.sendCameraCoTToMulticast(ctx); err != nil {
+		g.Log.Error().Err(err).Msg("Failed to send camera CoT to multicast")
+	}
+
+	return true
+}
+
+func (g *GPSService) reserveCoTMulticastSend() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if time.Since(g.lastMulticastTime) < cotMulticastRateLimit {
+		return false
+	}
+
+	g.lastMulticastTime = time.Now()
+
+	return true
+}
+
+func (g *GPSService) sendCameraCoTToMulticast(ctx context.Context) error {
+	pos := g.GetPosition()
+	if !pos.Valid {
+		return fmt.Errorf("no valid GPS position")
+	}
+
+	stream, err := camera.ResolveStream(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve camera stream: %w", err)
+	}
+
+	callsign := nodeCallsign()
+
+	return camera.Publish(ctx, camera.Position{
+		Altitude:        pos.Altitude,
+		CE:              pos.EPH,
+		GeoidSeparation: pos.GeoidSeparation,
+		Lat:             pos.Latitude,
+		LE:              pos.EPV,
+		Lon:             pos.Longitude,
+		Speed:           pos.Speed,
+		Track:           pos.Track,
+	}, camera.Node{
+		Callsign: callsign,
+		UID:      callsign,
+	}, stream)
 }
 
 // checkDeviceActive performs an ARP request to check if a device is active at the given IP address
@@ -178,17 +237,7 @@ func (g *GPSService) sendCoTToMulticast() error {
 		g.Log.Warn().Err(err).Msg("Failed to get board config info for CoT message")
 	}
 
-	// Get hostname for callsign
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "openmanet-node"
-	}
-
-	// If hostname does not contain the string manet
-	// append -MANET to the callsign to makeit clear these are MANET nodes in ATAK
-	if !strings.Contains(hostname, "manet") {
-		hostname = fmt.Sprintf("%s-MANET", hostname)
-	}
+	hostname := nodeCallsign()
 
 	// Get platform name, handle nil deviceInfo
 	platformName := "OpenMANET"
@@ -283,6 +332,20 @@ func (g *GPSService) sendCoTToMulticast() error {
 		Msg("Sent CoT message to ATAK SA multicast")
 
 	return nil
+}
+
+func nodeCallsign() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "openmanet-node"
+	}
+
+	// Preserve the existing MANET suffix used by normal radio markers.
+	if !strings.Contains(hostname, "manet") {
+		hostname = fmt.Sprintf("%s-MANET", hostname)
+	}
+
+	return hostname
 }
 
 // sendCoTAsExternalGPS creates and sends an ATAK CoT message to the EUD.

--- a/internal/gpsd/cot_test.go
+++ b/internal/gpsd/cot_test.go
@@ -1,12 +1,14 @@
 package gpsd
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
 )
 
 // Tests for cot.go functions:
@@ -14,6 +16,19 @@ import (
 // - checkDeviceActive
 // - sendCoTToMulticast
 // - sendCoTTAsExternalGPS
+
+func TestSendCameraCoTIfPresent_suppressesRadioMarker(t *testing.T) {
+	gps := &GPSService{
+		Log:               zerolog.Nop(),
+		cameraPresent:     true,
+		lastMulticastTime: time.Now(),
+	}
+
+	assert.True(t, gps.sendCameraCoTIfPresent(context.Background()), "camera update must suppress the radio marker")
+
+	gps.cameraPresent = false
+	assert.False(t, gps.sendCameraCoTIfPresent(context.Background()), "non-camera update must retain the radio path")
+}
 
 func TestSendCoTToMulticast(t *testing.T) {
 	log := zerolog.Nop()

--- a/internal/gpsd/cot_test.go
+++ b/internal/gpsd/cot_test.go
@@ -1,6 +1,7 @@
 package gpsd
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"sync"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Tests for cot.go functions:
@@ -28,6 +30,52 @@ func TestSendCameraCoTIfPresent_suppressesRadioMarker(t *testing.T) {
 
 	gps.cameraPresent = false
 	assert.False(t, gps.sendCameraCoTIfPresent(context.Background()), "non-camera update must retain the radio path")
+}
+
+func TestSendIfRequiredAsCoT_cameraSuppressesNormalPath(t *testing.T) {
+	var logs bytes.Buffer
+
+	gps := &GPSService{
+		Log:               zerolog.New(&logs),
+		cameraPresent:     true,
+		lastMulticastTime: time.Now(),
+		position:          PositionReport{Valid: true},
+	}
+
+	gps.SendIfRequiredAsCoT()
+
+	assert.NotContains(t, logs.String(), "Error getting DHCP leases")
+}
+
+func TestSendCameraCoTIfPresent_publishErrorStillOwnsUpdate(t *testing.T) {
+	var logs bytes.Buffer
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	gps := &GPSService{
+		Log:           zerolog.New(&logs),
+		cameraPresent: true,
+		position:      PositionReport{Valid: true},
+	}
+
+	assert.True(t, gps.sendCameraCoTIfPresent(ctx))
+	assert.Contains(t, logs.String(), "Failed to send camera CoT to multicast")
+}
+
+func TestReserveCoTMulticastSend(t *testing.T) {
+	gps := &GPSService{}
+
+	assert.True(t, gps.reserveCoTMulticastSend())
+	assert.False(t, gps.reserveCoTMulticastSend())
+}
+
+func TestSendCameraCoTToMulticast_invalidPosition(t *testing.T) {
+	gps := &GPSService{}
+
+	err := gps.sendCameraCoTToMulticast(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no valid GPS position")
 }
 
 func TestSendCoTToMulticast(t *testing.T) {

--- a/internal/gpsd/types.go
+++ b/internal/gpsd/types.go
@@ -111,4 +111,5 @@ type GPSService struct {
 	reconnectDelay    time.Duration
 	reconnectAttempts int
 	mu                sync.RWMutex
+	cameraPresent     bool
 }

--- a/internal/mgmt/device.go
+++ b/internal/mgmt/device.go
@@ -115,6 +115,7 @@ func (m *ManagementConfig) setupBatMesh1Interface(ctx context.Context) error {
 		m.uciOpenMANETConfig,
 		network.NewUCIWirelessConfigReader(),
 		iwinfo.NewClient(),
+		network.NewDefaultWirelessStatusProvider(),
 	)
 }
 
@@ -122,12 +123,11 @@ func (m *ManagementConfig) setupBatMesh1Interface(ctx context.Context) error {
 // wireless interface. It is idempotent: if batmesh1configured is already set to
 // true the method returns immediately. The method:
 //
-//  1. Checks that at least one wireless interface uses a supported MediaTek
-//     chipset (MT7915 or MT7916) via iwinfo.
-//  2. Locates an existing wifi-iface with mode=mesh and borrows its mesh_id and
+//  1. Returns without changes when batmesh1 is already configured.
+//  2. Correlates each 2.4 GHz UCI radio with its runtime interface and selects
+//     a single radio backed by an MT7915 or MT7916 chipset.
+//  3. Locates an existing wifi-iface with mode=mesh and borrows its mesh_id and
 //     key values.
-//  3. Locates the wifi-device with band=2g and derives the new interface section
-//     name as "default_<radioSection>".
 //  4. Creates the new wifi-iface with network=batmesh1, mode=mesh,
 //     mesh_fwding=0, encryption=sae, and the borrowed credentials.
 //  5. Updates the matched 2g radio with channel=8 and htmode=HE20.
@@ -137,6 +137,7 @@ func (m *ManagementConfig) setupBatMesh1InterfaceWithDeps(
 	openmanetReader network.OpenMANETConfigReader,
 	wirelessReader network.ConfigReader,
 	iwinfoProvider iwinfo.IwinfoProvider,
+	wirelessStatus network.WirelessStatusProvider,
 ) error {
 	// Step 1: guard — return early if already configured.
 	configured, err := network.IsBatMesh1ConfiguredWithReader(openmanetReader)
@@ -156,21 +157,42 @@ func (m *ManagementConfig) setupBatMesh1InterfaceWithDeps(
 		return fmt.Errorf("get iwinfo for all devices: %w", err)
 	}
 
-	var supportedHardwareFound bool
+	status, err := wirelessStatus.GetWirelessStatus(ctx)
+	if err != nil {
+		m.Log.Debug().Err(err).Msg("Wireless status unavailable; skipping batmesh1 configuration")
 
-	for _, info := range allInfo {
-		name := info.Hardware.GetName()
-		if strings.Contains(name, "MT7915") || strings.Contains(name, "MT7916") {
-			m.Log.Debug().Str("hardware", name).Msg("Found supported MediaTek chipset for batmesh1")
-
-			supportedHardwareFound = true
-
-			break
-		}
+		return nil
 	}
 
-	if !supportedHardwareFound {
-		m.Log.Debug().Msg("No supported MediaTek hardware (MT7915 or MT7916) found for batmesh1 configuration")
+	deviceSections, err := wirelessReader.GetSections("wireless", "wifi-device")
+	if err != nil {
+		return fmt.Errorf("get wifi-device sections: %w", err)
+	}
+
+	var radioSection string
+
+	for _, section := range deviceSections {
+		device, deviceErr := network.GetWirelessDeviceByNameWithReader(section, wirelessReader)
+		if deviceErr != nil || device.Band != "2g" {
+			continue
+		}
+
+		hardwareName := network.ResolveWirelessRadioHardwareName(section, status, allInfo)
+		if !strings.Contains(hardwareName, "MT7915") && !strings.Contains(hardwareName, "MT7916") {
+			continue
+		}
+
+		if radioSection != "" {
+			m.Log.Debug().Msg("Multiple supported 2.4 GHz radios found; skipping batmesh1 configuration")
+
+			return nil
+		}
+
+		radioSection = section
+	}
+
+	if radioSection == "" {
+		m.Log.Debug().Msg("No MT7915/MT7916 2.4 GHz radio found for batmesh1 configuration")
 
 		return nil
 	}
@@ -201,34 +223,9 @@ func (m *ManagementConfig) setupBatMesh1InterfaceWithDeps(
 		return fmt.Errorf("no existing wifi-iface with mode=mesh found; cannot determine mesh credentials")
 	}
 
-	// Step 4: find the 2g radio.
-	deviceSections, err := wirelessReader.GetSections("wireless", "wifi-device")
-	if err != nil {
-		return fmt.Errorf("get wifi-device sections: %w", err)
-	}
-
-	var radioSection string
-
-	for _, section := range deviceSections {
-		dev, derr := network.GetWirelessDeviceByNameWithReader(section, wirelessReader)
-		if derr != nil {
-			continue
-		}
-
-		if dev.Band == "2g" {
-			radioSection = section
-
-			break
-		}
-	}
-
-	if radioSection == "" {
-		return fmt.Errorf("no wifi-device with band=2g found")
-	}
-
 	newIfaceSection := "default_" + radioSection
 
-	// Step 5: create the new wifi-iface.
+	// Step 4: create the new wifi-iface.
 	newIface := &network.UCIWirelessIface{
 		Device:     radioSection,
 		Network:    "batmesh1",
@@ -245,7 +242,7 @@ func (m *ManagementConfig) setupBatMesh1InterfaceWithDeps(
 
 	m.Log.Info().Str("section", newIfaceSection).Str("device", radioSection).Msg("Created batmesh1 wifi-iface")
 
-	// Step 6: update the 2g radio device.
+	// Step 5: update the 2g radio device.
 	radioUpdate := &network.UCIWirelessDevice{
 		Channel:  "8",
 		HTMode:   "HE20",
@@ -258,7 +255,7 @@ func (m *ManagementConfig) setupBatMesh1InterfaceWithDeps(
 
 	m.Log.Info().Str("section", radioSection).Str("channel", "8").Str("htmode", "HE20").Str("disabled", "0").Msg("Updated 2g radio for batmesh1")
 
-	// Step 7: mark batmesh1 as configured.
+	// Step 6: mark batmesh1 as configured.
 	if err := network.SetBatMesh1ConfiguredWithReader(openmanetReader); err != nil {
 		return fmt.Errorf("mark batmesh1 configured: %w", err)
 	}

--- a/internal/mgmt/device_test.go
+++ b/internal/mgmt/device_test.go
@@ -390,6 +390,37 @@ func TestSetupBatMesh1Interface_IwinfoError(t *testing.T) {
 	}
 }
 
+func TestSetupBatMesh1Interface_WirelessStatusError(t *testing.T) {
+	m := newTestManagementConfig()
+	openmanet := newFakeOpenMANETReader()
+	openmanet.seedBatMesh1Configured("0")
+
+	wireless := newFakeWirelessReader()
+	status := &fakeWirelessStatusProvider{Err: errors.New("ubus unavailable")}
+
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, &fakeIwinfo{}, status)
+	require.NoError(t, err)
+	assert.Zero(t, wireless.commitCalls)
+	assert.Zero(t, openmanet.commitCalls)
+}
+
+func TestSetupBatMesh1Interface_DeviceSectionsError(t *testing.T) {
+	m := newTestManagementConfig()
+	openmanet := newFakeOpenMANETReader()
+	openmanet.seedBatMesh1Configured("0")
+
+	wireless := newFakeWirelessReader()
+	reader := &sectionErrorReader{
+		ConfigReader: wireless,
+		sectionType:  "wifi-device",
+		err:          errors.New("read devices"),
+	}
+
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, reader, &fakeIwinfo{}, &fakeWirelessStatusProvider{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "get wifi-device sections")
+}
+
 func TestSetupBatMesh1Interface_HardwareMatch_MT7915(t *testing.T) {
 	m := newTestManagementConfig()
 	openmanet := newFakeOpenMANETReader()
@@ -453,6 +484,25 @@ func TestSetupBatMesh1Interface_NoMeshIface(t *testing.T) {
 	if !strings.Contains(err.Error(), "no existing wifi-iface with mode=mesh") {
 		t.Errorf("unexpected error message: %v", err)
 	}
+}
+
+func TestSetupBatMesh1Interface_IfaceSectionsError(t *testing.T) {
+	m := newTestManagementConfig()
+	openmanet := newFakeOpenMANETReader()
+	openmanet.seedBatMesh1Configured("0")
+
+	wireless := newFakeWirelessReader()
+	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
+	reader := &sectionErrorReader{
+		ConfigReader: wireless,
+		sectionType:  "wifi-iface",
+		err:          errors.New("read interfaces"),
+	}
+	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
+
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, reader, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "get wifi-iface sections")
 }
 
 func TestSetupBatMesh1Interface_No2gDevice(t *testing.T) {
@@ -590,6 +640,29 @@ func TestSetupBatMesh1Interface_doesNotTouchUnrelated2gRadio(t *testing.T) {
 	iface, err := network.GetWirelessIfaceByNameWithReader("default_radio1", wireless)
 	require.NoError(t, err)
 	assert.Equal(t, "radio1", iface.Device)
+}
+
+func TestSetupBatMesh1Interface_MultipleSupportedRadiosIsSafeNoOp(t *testing.T) {
+	m := newTestManagementConfig()
+	openmanet := newFakeOpenMANETReader()
+	openmanet.seedBatMesh1Configured("0")
+
+	wireless := newFakeWirelessReader()
+	wireless.seedWifiDevice("radio1", "2g", "1", "HT20")
+	wireless.seedWifiDevice("radio2", "2g", "6", "HT20")
+
+	iw := &fakeIwinfo{infoMap: map[string]*iwinfo.InterfaceInfo{
+		"phy1": {Hardware: iwinfo.HardwareInfo{Name: "MediaTek MT7915AN"}},
+		"phy2": {Hardware: iwinfo.HardwareInfo{Name: "MediaTek MT7916AN"}},
+	}}
+	status := &fakeWirelessStatusProvider{Status: map[string]*network.WirelessRadioStatus{
+		"radio1": {Interfaces: []network.WirelessRadioInterface{{Ifname: "phy1"}}},
+		"radio2": {Interfaces: []network.WirelessRadioInterface{{Ifname: "phy2"}}},
+	}}
+
+	require.NoError(t, m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, status))
+	assert.Zero(t, wireless.commitCalls)
+	assert.Zero(t, openmanet.commitCalls)
 }
 
 func TestSetupBatMesh1Interface_SetIfaceError(t *testing.T) {

--- a/internal/mgmt/device_test.go
+++ b/internal/mgmt/device_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/openmanet/openmanetd/internal/iwinfo"
 	"github.com/openmanet/openmanetd/internal/network"
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ── fakeOpenMANETReader ──────────────────────────────────────────────────────
@@ -339,7 +341,7 @@ func TestSetupBatMesh1Interface_AlreadyConfigured(t *testing.T) {
 	wireless := newFakeWirelessReader()
 	iw := &fakeIwinfo{} // no calls expected
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, nil)
 	if err != nil {
 		t.Fatalf("expected nil for already-configured, got %v", err)
 	}
@@ -360,7 +362,7 @@ func TestSetupBatMesh1Interface_OpenMANETCheckError(t *testing.T) {
 	wireless := newFakeWirelessReader()
 	iw := &fakeIwinfo{}
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, nil)
 	if err == nil {
 		t.Fatal("expected error from invalid batmesh1configured value")
 	}
@@ -378,7 +380,7 @@ func TestSetupBatMesh1Interface_IwinfoError(t *testing.T) {
 	wireless := newFakeWirelessReader()
 	iw := &fakeIwinfo{infoMapErr: errors.New("ubus not available")}
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, nil)
 	if err == nil {
 		t.Fatal("expected error when iwinfo fails")
 	}
@@ -394,10 +396,11 @@ func TestSetupBatMesh1Interface_HardwareMatch_MT7915(t *testing.T) {
 	openmanet.seedBatMesh1Configured("0")
 
 	wireless := newFakeWirelessReader()
+	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
 	// No mesh iface seeded — expect it to fail past the hardware check.
 	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
 	// Should fail at "no mesh iface", not at "no supported hardware".
 	if err == nil {
 		t.Fatal("expected error after hardware check (no mesh iface)")
@@ -414,9 +417,11 @@ func TestSetupBatMesh1Interface_HardwareMatch_MT7916(t *testing.T) {
 	openmanet.seedBatMesh1Configured("0")
 
 	wireless := newFakeWirelessReader()
+	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
+
 	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7916AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
 	// Should fail at "no mesh iface", not at "no supported hardware".
 	if err == nil {
 		t.Fatal("expected error after hardware check (no mesh iface)")
@@ -436,10 +441,11 @@ func TestSetupBatMesh1Interface_NoMeshIface(t *testing.T) {
 	// Seed only a non-mesh iface.
 	_ = wireless.AddSection("wireless", "default_radio0", "wifi-iface")
 	_ = wireless.SetType("wireless", "default_radio0", "mode", uci.TypeOption, "ap")
+	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
 
 	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
 	if err == nil {
 		t.Fatal("expected error when no mesh iface found")
 	}
@@ -461,13 +467,13 @@ func TestSetupBatMesh1Interface_No2gDevice(t *testing.T) {
 
 	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
-	if err == nil {
-		t.Fatal("expected error when no 2g device found")
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio4", "wlan0"))
+	if err != nil {
+		t.Fatalf("expected safe no-op when no supported 2.4 GHz radio exists, got %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "no wifi-device with band=2g") {
-		t.Errorf("unexpected error message: %v", err)
+	if wireless.commitCalls != 0 || openmanet.commitCalls != 0 {
+		t.Fatal("unsupported radio configuration was modified")
 	}
 }
 
@@ -482,7 +488,7 @@ func TestSetupBatMesh1Interface_Success(t *testing.T) {
 
 	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -551,6 +557,41 @@ func TestSetupBatMesh1Interface_Success(t *testing.T) {
 	}
 }
 
+func TestSetupBatMesh1Interface_doesNotTouchUnrelated2gRadio(t *testing.T) {
+	m := newTestManagementConfig()
+	openmanet := newFakeOpenMANETReader()
+	openmanet.seedBatMesh1Configured("0")
+
+	wireless := newFakeWirelessReader()
+	wireless.seedMeshIface("existing_mesh0", "radio4", "halowmesh", "secretkey")
+	wireless.seedWifiDevice("radio0", "2g", "1", "HT20")
+	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
+
+	iw := &fakeIwinfo{infoMap: map[string]*iwinfo.InterfaceInfo{
+		"phy0-ap0":   {Hardware: iwinfo.HardwareInfo{Name: "Broadcom BCM43430"}},
+		"phy1-mesh0": {Hardware: iwinfo.HardwareInfo{Name: "MediaTek MT7915AN"}},
+	}}
+	status := &fakeWirelessStatusProvider{Status: map[string]*network.WirelessRadioStatus{
+		"radio0": {Interfaces: []network.WirelessRadioInterface{{Ifname: "phy0-ap0"}}},
+		"radio1": {Interfaces: []network.WirelessRadioInterface{{Ifname: "phy1-mesh0"}}},
+	}}
+
+	require.NoError(t, m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, status))
+
+	_, createdOnboardMesh := wireless.Get("wireless", "default_radio0", "device")
+	assert.False(t, createdOnboardMesh, "must not create batmesh1 on the unrelated onboard radio")
+
+	radio0, err := network.GetWirelessDeviceByNameWithReader("radio0", wireless)
+	require.NoError(t, err)
+	assert.Equal(t, "1", radio0.Channel)
+	assert.Equal(t, "HT20", radio0.HTMode)
+	assert.Empty(t, radio0.Disabled)
+
+	iface, err := network.GetWirelessIfaceByNameWithReader("default_radio1", wireless)
+	require.NoError(t, err)
+	assert.Equal(t, "radio1", iface.Device)
+}
+
 func TestSetupBatMesh1Interface_SetIfaceError(t *testing.T) {
 	m := newTestManagementConfig()
 	openmanet := newFakeOpenMANETReader()
@@ -563,7 +604,7 @@ func TestSetupBatMesh1Interface_SetIfaceError(t *testing.T) {
 
 	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
 	if err == nil {
 		t.Fatal("expected error when SetWirelessIface fails")
 	}
@@ -588,7 +629,7 @@ func TestSetupBatMesh1Interface_SetDeviceError(t *testing.T) {
 
 	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
 	if err == nil {
 		t.Fatal("expected error when Commit fails")
 	}
@@ -611,7 +652,7 @@ func TestSetupBatMesh1Interface_SetConfiguredError(t *testing.T) {
 
 	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
 	if err == nil {
 		t.Fatal("expected error when openmanet Commit fails")
 	}
@@ -632,7 +673,7 @@ func TestSetupBatMesh1Interface_IdempotentWhenAlreadyConfigured(t *testing.T) {
 
 	iw := &fakeIwinfo{infoMapErr: errors.New("should not be called")}
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw)
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, nil)
 	if err != nil {
 		t.Fatalf("expected nil for already-configured (idempotency check), got %v", err)
 	}

--- a/internal/mgmt/mocks_test.go
+++ b/internal/mgmt/mocks_test.go
@@ -15,6 +15,21 @@ type fakeWirelessStatusProvider struct {
 	Err    error
 }
 
+type sectionErrorReader struct {
+	network.ConfigReader
+
+	sectionType string
+	err         error
+}
+
+func (r *sectionErrorReader) GetSections(config, sectionType string) ([]string, error) {
+	if sectionType == r.sectionType {
+		return nil, r.err
+	}
+
+	return r.ConfigReader.GetSections(config, sectionType)
+}
+
 func (f *fakeWirelessStatusProvider) GetWirelessStatus(_ context.Context) (map[string]*network.WirelessRadioStatus, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()

--- a/internal/mgmt/mocks_test.go
+++ b/internal/mgmt/mocks_test.go
@@ -1,0 +1,31 @@
+package mgmt
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/openmanet/openmanetd/internal/network"
+)
+
+type fakeWirelessStatusProvider struct {
+	mu sync.RWMutex // protects the fields below
+
+	Status map[string]*network.WirelessRadioStatus
+	Err    error
+}
+
+func (f *fakeWirelessStatusProvider) GetWirelessStatus(_ context.Context) (map[string]*network.WirelessRadioStatus, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	return f.Status, f.Err
+}
+
+func wirelessStatusForRadio(t *testing.T, radio, ifname string) *fakeWirelessStatusProvider {
+	t.Helper()
+
+	return &fakeWirelessStatusProvider{Status: map[string]*network.WirelessRadioStatus{
+		radio: {Interfaces: []network.WirelessRadioInterface{{Ifname: ifname}}},
+	}}
+}

--- a/internal/network/wireless_status.go
+++ b/internal/network/wireless_status.go
@@ -22,6 +22,32 @@ type WirelessRadioInterface struct {
 	Config  WirelessIfaceStatusConfig `json:"config"`
 }
 
+// ResolveWirelessRadioHardwareName correlates a UCI radio section with its
+// runtime interfaces and returns the first hardware name reported by iwinfo.
+func ResolveWirelessRadioHardwareName(
+	radioName string,
+	status map[string]*WirelessRadioStatus,
+	iwinfoData map[string]*iwinfo.InterfaceInfo,
+) string {
+	radio, ok := status[radioName]
+	if !ok || radio == nil {
+		return ""
+	}
+
+	for _, iface := range radio.Interfaces {
+		info, ok := iwinfoData[iface.Ifname]
+		if !ok || info == nil {
+			continue
+		}
+
+		if hardwareName := info.GetHardwareName(); hardwareName != "" {
+			return hardwareName
+		}
+	}
+
+	return ""
+}
+
 // WirelessIfaceStatusConfig is the nested config block inside the ubus response.
 type WirelessIfaceStatusConfig struct {
 	Mode string `json:"mode"`

--- a/internal/network/wireless_status_test.go
+++ b/internal/network/wireless_status_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/openmanet/openmanetd/internal/iwinfo"
+	"github.com/stretchr/testify/assert"
 )
 
 type wsUbusExecutor struct {
@@ -92,6 +95,23 @@ func TestGetWirelessStatus_MultipleRadios(t *testing.T) {
 	if r3.Interfaces[0].Config.Mode != "mesh" {
 		t.Errorf("expected mode mesh, got %s", r3.Interfaces[0].Config.Mode)
 	}
+}
+
+func TestResolveWirelessRadioHardwareName_interfaces(t *testing.T) {
+	t.Parallel()
+
+	status := map[string]*WirelessRadioStatus{
+		"radio2": {Interfaces: []WirelessRadioInterface{
+			{Ifname: "missing"},
+			{Ifname: "phy1-mesh0"},
+		}},
+	}
+	info := map[string]*iwinfo.InterfaceInfo{
+		"phy1-mesh0": {Hardware: iwinfo.HardwareInfo{Name: "MediaTek MT7915AN"}},
+	}
+
+	assert.Equal(t, "MediaTek MT7915AN", ResolveWirelessRadioHardwareName("radio2", status, info))
+	assert.Empty(t, ResolveWirelessRadioHardwareName("missing", status, info))
 }
 
 func TestGetWirelessStatus_DisabledRadio(t *testing.T) {

--- a/internal/network/wireless_status_test.go
+++ b/internal/network/wireless_status_test.go
@@ -112,6 +112,7 @@ func TestResolveWirelessRadioHardwareName_interfaces(t *testing.T) {
 
 	assert.Equal(t, "MediaTek MT7915AN", ResolveWirelessRadioHardwareName("radio2", status, info))
 	assert.Empty(t, ResolveWirelessRadioHardwareName("missing", status, info))
+	assert.Empty(t, ResolveWirelessRadioHardwareName("radio2", status, nil))
 }
 
 func TestGetWirelessStatus_DisabledRadio(t *testing.T) {

--- a/internal/openmanet/server/handlers/wifi_config.go
+++ b/internal/openmanet/server/handlers/wifi_config.go
@@ -113,7 +113,7 @@ func (s *WifiConfigService) ListRadios(ctx context.Context, _ *emptypb.Empty) (*
 		ifaceName := findLinkedIface(devName, ifaceSections, s.ConfigReader)
 
 		// Determine hardware name from iwinfo by matching ifname.
-		hardwareName := resolveHardwareName(devName, wsStatus, iwinfoData)
+		hardwareName := network.ResolveWirelessRadioHardwareName(devName, wsStatus, iwinfoData)
 
 		displayName := FormatBandDisplayName(WifiBandToProto(dev.Band))
 		if hardwareName != "" {
@@ -503,29 +503,6 @@ func findUnusedBatmesh(reader network.ConfigReader, excludeIface string) (string
 	}
 
 	return "", fmt.Errorf("no available batmesh network (all in use)")
-}
-
-// resolveHardwareName looks up the hardware chip name by correlating the UCI
-// radio to its running Linux interface name, then matching that to iwinfo data.
-func resolveHardwareName(radioName string, wsStatus map[string]*network.WirelessRadioStatus,
-	iwinfoData map[string]*iwinfo.InterfaceInfo) string {
-	if wsStatus == nil || iwinfoData == nil {
-		return ""
-	}
-
-	rs, ok := wsStatus[radioName]
-	if !ok || len(rs.Interfaces) == 0 {
-		return ""
-	}
-
-	ifname := rs.Interfaces[0].Ifname
-
-	info, ok := iwinfoData[ifname]
-	if !ok || info == nil {
-		return ""
-	}
-
-	return info.GetHardwareName()
 }
 
 // resolveIfname maps a UCI radio name to the running Linux interface name.


### PR DESCRIPTION
Adds one camera CoT marker for camera-equipped nodes while suppressing the normal radio marker.

Batmesh1 setup now changes only the UCI 2.4 GHz radio correlated to an MT7915 or MT7916 chipset, leaving unrelated onboard radios untouched.

Validation: focused unit tests, race detector, go vet, and focused golangci-lint. Full Make checks are blocked on this host by the existing PAM/Cgo C.RTLD_NEXT failure.