### PR TITLE
fix: hardware audio init retry/recovery for OpenVLM + wlan->wlh rename

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -131,7 +131,8 @@
     "claude-md-management@claude-plugins-official": true,
     "github@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "caveman@caveman": true
   },
   "extraKnownMarketplaces": {
     "caveman": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,9 +44,7 @@
   "containerEnv": {
     "SOURCE_FILEPATH": "${localWorkspaceFolder}"
   },
-  "mounts": [
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.claude,target=/home/vscode/.claude,type=bind"
-  ],
+  "mounts": [],
   // The optional 'runArgs' property can be used to specify additional runtime arguments.
   "runArgs": [
     // Uncomment the next line if you will use a ptrace-based debugger like C++, Go, and Rust

--- a/frontend/src/__tests__/components/Dashboard.test.jsx
+++ b/frontend/src/__tests__/components/Dashboard.test.jsx
@@ -151,7 +151,7 @@ function makeNetworkInterfaceList() {
     interfaces: [
       makeNetworkInterface({ name: 'eth0', type: 2, status: 2, rxBytes: BigInt(1024), txBytes: BigInt(2048) }),
       makeNetworkInterface({ name: 'br-ahwlan', type: 1, status: 1, ipAddress: '10.41.25.72/16', rxBytes: BigInt(142300000), txBytes: BigInt(87600000) }),
-      makeNetworkInterface({ name: 'wlan0', type: 3, status: 1, ipAddress: '', rxBytes: BigInt(2048), txBytes: BigInt(4096) }),
+      makeNetworkInterface({ name: 'wlh0', type: 3, status: 1, ipAddress: '', rxBytes: BigInt(2048), txBytes: BigInt(4096) }),
       makeNetworkInterface({ name: 'phy1-ap0', type: 4, status: 1, rxBytes: BigInt(12345678), txBytes: BigInt(9876543) }),
       makeNetworkInterface({ name: 'bat0', type: 5, status: 1, rxBytes: BigInt(5_000_000_000), txBytes: BigInt(3_000_000_000) }),
       makeNetworkInterface({ name: 'tailscale0', type: 7, status: 2, rxBytes: BigInt(0), txBytes: BigInt(0) }),
@@ -325,7 +325,7 @@ describe('TestDashboardPanels', () => {
       expect(table.querySelectorAll('tbody tr').length).toBe(6);
     });
     expect(table.textContent).toContain('eth0');
-    expect(table.textContent).toContain('wlan0');
+    expect(table.textContent).toContain('wlh0');
     expect(table.textContent).toContain('bat0');
     expect(table.textContent).toContain('tailscale0');
     // Loopback is hidden from the operator-facing summary.

--- a/frontend/src/__tests__/components/SettingsNetwork.test.jsx
+++ b/frontend/src/__tests__/components/SettingsNetwork.test.jsx
@@ -34,7 +34,7 @@ afterEach(() => {
 
 const INTERFACES = [
   { name: 'eth0', type: 2, status: 1, ipAddress: '192.168.1.1', macAddress: 'aa:bb:cc:dd:ee:01', rxBytes: 1048576, txBytes: 524288, mtu: 1500 },
-  { name: 'wlan0', type: 4, status: 1, ipAddress: '10.41.1.1', macAddress: 'aa:bb:cc:dd:ee:02', rxBytes: 2097152, txBytes: 1048576, mtu: 1500 },
+  { name: 'wlh0', type: 4, status: 1, ipAddress: '10.41.1.1', macAddress: 'aa:bb:cc:dd:ee:02', rxBytes: 2097152, txBytes: 1048576, mtu: 1500 },
   { name: 'br-lan', type: 1, status: 2, ipAddress: '', macAddress: 'aa:bb:cc:dd:ee:03', rxBytes: 0, txBytes: 0, mtu: 1500 },
 ];
 
@@ -72,7 +72,7 @@ describe('TestNetworkInterfacesRender', () => {
     render(<SettingsNetworkPage />);
     await waitFor(() => {
       expect(screen.getByText('eth0')).toBeTruthy();
-      expect(screen.getByText('wlan0')).toBeTruthy();
+      expect(screen.getByText('wlh0')).toBeTruthy();
       expect(screen.getAllByText('br-lan').length).toBeGreaterThanOrEqual(1);
     });
     // Type labels

--- a/frontend/src/__tests__/components/TopologyMap.test.jsx
+++ b/frontend/src/__tests__/components/TopologyMap.test.jsx
@@ -38,7 +38,7 @@ function directRF() {
       { mac: '00:00:00:00:00:00', hostname: 'BCM2711-me01', segment: 'local',
         hopsFromSelf: 0, isSelf: true, myHardIfname: '' },
       { mac: 'aa:aa:aa:aa:aa:01', hostname: 'BCM2711-alpha', segment: 'local',
-        hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
+        hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
     ],
     edges: [
       { fromMac: '00:00:00:00:00:00', toMac: 'aa:aa:aa:aa:aa:01',
@@ -56,7 +56,7 @@ function withBLOSGateway() {
       { mac: '00:00:00:00:00:00', hostname: 'BCM2711-me01', segment: 'local',
         hopsFromSelf: 0, isSelf: true, myHardIfname: '' },
       { mac: 'aa:aa:aa:aa:aa:01', hostname: 'BCM2711-alpha', segment: 'local',
-        hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
+        hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
       { mac: 'cc:cc:cc:cc:cc:01', hostname: 'BCM2711-gw1', segment: 'remote',
         hopsFromSelf: 1, isSelf: false, myHardIfname: 'vxlan0' },
     ],
@@ -199,10 +199,10 @@ function chainAndSingleton() {
     algorithm: 'BATMAN_V',
     nodes: [
       { mac: 'aa:aa:aa:aa:aa:00', hostname: 'gw',  segment: 'local', hopsFromSelf: 0, isSelf: true,  myHardIfname: '' },
-      { mac: 'bb:bb:bb:bb:bb:00', hostname: 'B',   segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
-      { mac: 'dd:dd:dd:dd:dd:00', hostname: 'D',   segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
-      { mac: 'cc:cc:cc:cc:cc:00', hostname: 'A',   segment: 'local', hopsFromSelf: 2, isSelf: false, myHardIfname: 'wlan0' },
-      { mac: 'ee:ee:ee:ee:ee:00', hostname: 'C',   segment: 'local', hopsFromSelf: 3, isSelf: false, myHardIfname: 'wlan0' },
+      { mac: 'bb:bb:bb:bb:bb:00', hostname: 'B',   segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
+      { mac: 'dd:dd:dd:dd:dd:00', hostname: 'D',   segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
+      { mac: 'cc:cc:cc:cc:cc:00', hostname: 'A',   segment: 'local', hopsFromSelf: 2, isSelf: false, myHardIfname: 'wlh0' },
+      { mac: 'ee:ee:ee:ee:ee:00', hostname: 'C',   segment: 'local', hopsFromSelf: 3, isSelf: false, myHardIfname: 'wlh0' },
     ],
     edges: [
       { fromMac: 'aa:aa:aa:aa:aa:00', toMac: 'bb:bb:bb:bb:bb:00', metric: 1.1, blos: false, onMyPath: true },
@@ -241,7 +241,7 @@ describe('TestTopologyMapTreeLayout', () => {
     const topology = chainAndSingleton();
     topology.nodes.push({
       mac: 'ff:ff:ff:ff:ff:00', hostname: 'Z', segment: 'local',
-      hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0',
+      hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0',
     });
     // No edges referencing Z — it should still land on the canvas.
 
@@ -268,10 +268,10 @@ function ringWithCrossEdge() {
     algorithm: 'BATMAN_V',
     nodes: [
       { mac: 'aa:aa:aa:aa:aa:00', hostname: 'gw', segment: 'local', hopsFromSelf: 0, isSelf: true,  myHardIfname: '' },
-      { mac: 'bb:bb:bb:bb:bb:00', hostname: 'A',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
-      { mac: 'cc:cc:cc:cc:cc:00', hostname: 'B',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
-      { mac: 'dd:dd:dd:dd:dd:00', hostname: 'C',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
-      { mac: 'ee:ee:ee:ee:ee:00', hostname: 'D',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
+      { mac: 'bb:bb:bb:bb:bb:00', hostname: 'A',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
+      { mac: 'cc:cc:cc:cc:cc:00', hostname: 'B',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
+      { mac: 'dd:dd:dd:dd:dd:00', hostname: 'C',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
+      { mac: 'ee:ee:ee:ee:ee:00', hostname: 'D',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
     ],
     edges: [
       { fromMac: 'aa:aa:aa:aa:aa:00', toMac: 'bb:bb:bb:bb:bb:00', metric: 15, blos: false, onMyPath: true },
@@ -327,10 +327,10 @@ describe('TestTopologyMapHybridLayout', () => {
       algorithm: 'BATMAN_V',
       nodes: [
         { mac: 'aa:aa:aa:aa:aa:00', hostname: 'gw', segment: 'local', hopsFromSelf: 0, isSelf: true,  myHardIfname: '' },
-        { mac: 'bb:bb:bb:bb:bb:00', hostname: 'A',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
-        { mac: 'cc:cc:cc:cc:cc:00', hostname: 'B',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
-        { mac: 'dd:dd:dd:dd:dd:00', hostname: 'C',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
-        { mac: 'ee:ee:ee:ee:ee:00', hostname: 'D',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
+        { mac: 'bb:bb:bb:bb:bb:00', hostname: 'A',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
+        { mac: 'cc:cc:cc:cc:cc:00', hostname: 'B',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
+        { mac: 'dd:dd:dd:dd:dd:00', hostname: 'C',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
+        { mac: 'ee:ee:ee:ee:ee:00', hostname: 'D',  segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
       ],
       // Tree edges from gw to every sibling PLUS every sibling-pair edge.
       edges: [
@@ -489,7 +489,7 @@ describe('TestTopologyMapSegmentSizing', () => {
   // can check that a segment box contains every node's rendered
   // footprint (circle + secondary label). Before the label-aware
   // bbox pass, a segment with many children could have its right-
-  // most host's "HOPS 1 · wlan0" text spilling past the box edge.
+  // most host's "HOPS 1 · wlh0" text spilling past the box edge.
   function localWithSiblings(n) {
     const nodes = [{
       mac: '00:00:00:00:00:00', hostname: 'self', segment: 'local',
@@ -505,7 +505,7 @@ describe('TestTopologyMapSegmentSizing', () => {
         hopsFromSelf: 1,
         isSelf: false,
         clientCount: 0,
-        myHardIfname: 'wlan0',
+        myHardIfname: 'wlh0',
       });
       edges.push({ fromMac: '00:00:00:00:00:00', toMac: mac, metric: 1.2, blos: false, onMyPath: true });
     }
@@ -541,8 +541,8 @@ describe('TestTopologyMapSegmentSizing', () => {
       algorithm: 'BATMAN_V',
       nodes: [
         { mac: '00:00:00:00:00:00', hostname: 'self', segment: 'local', hopsFromSelf: 0, isSelf: true, myHardIfname: '' },
-        { mac: 'aa:aa:aa:aa:aa:01', hostname: 'BCM2711-a', segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
-        { mac: 'aa:aa:aa:aa:aa:02', hostname: 'BCM2711-b', segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0' },
+        { mac: 'aa:aa:aa:aa:aa:01', hostname: 'BCM2711-a', segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
+        { mac: 'aa:aa:aa:aa:aa:02', hostname: 'BCM2711-b', segment: 'local', hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0' },
         { mac: 'cc:cc:cc:cc:cc:01', hostname: 'BCM2711-gw', segment: 'remote', hopsFromSelf: 1, isSelf: false, myHardIfname: 'vxlan0' },
         { mac: 'cc:cc:cc:cc:cc:02', hostname: 'BCM2711-rm1', segment: 'remote', hopsFromSelf: 2, isSelf: false, myHardIfname: 'vxlan0' },
         { mac: 'cc:cc:cc:cc:cc:03', hostname: 'BCM2711-rm2', segment: 'remote', hopsFromSelf: 2, isSelf: false, myHardIfname: 'vxlan0' },

--- a/frontend/src/__tests__/components/topologyGraph.test.js
+++ b/frontend/src/__tests__/components/topologyGraph.test.js
@@ -28,12 +28,12 @@ function localTriangle() {
       },
       {
         mac: 'bb:bb:bb:bb:bb:00', hostname: 'alpha', segment: 'local',
-        hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0',
+        hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0',
         secondaryMacs: [],
       },
       {
         mac: 'cc:cc:cc:cc:cc:00', hostname: 'bravo', segment: 'local',
-        hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0',
+        hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0',
         secondaryMacs: [],
       },
     ],
@@ -56,7 +56,7 @@ function localAndRemote() {
     algorithm: 'BATMAN_V',
     nodes: [
       { mac: 'aa:aa:aa:aa:aa:00', hostname: 'me',     segment: 'local',  remoteGatewayMac: '',                     hopsFromSelf: 0, isSelf: true,  myHardIfname: '',       secondaryMacs: [] },
-      { mac: 'bb:bb:bb:bb:bb:00', hostname: 'alpha',  segment: 'local',  remoteGatewayMac: '',                     hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlan0',  secondaryMacs: [] },
+      { mac: 'bb:bb:bb:bb:bb:00', hostname: 'alpha',  segment: 'local',  remoteGatewayMac: '',                     hopsFromSelf: 1, isSelf: false, myHardIfname: 'wlh0',  secondaryMacs: [] },
       { mac: 'cc:cc:cc:cc:cc:00', hostname: 'gw1',    segment: 'remote', remoteGatewayMac: 'cc:cc:cc:cc:cc:00',    hopsFromSelf: 1, isSelf: false, myHardIfname: 'vxlan0', secondaryMacs: [] },
       { mac: 'dd:dd:dd:dd:dd:00', hostname: 'peer-e', segment: 'remote', remoteGatewayMac: 'cc:cc:cc:cc:cc:00',    hopsFromSelf: 2, isSelf: false, myHardIfname: 'vxlan0', secondaryMacs: [] },
       { mac: 'ee:ee:ee:ee:ee:00', hostname: 'peer-f', segment: 'remote', remoteGatewayMac: 'cc:cc:cc:cc:cc:00',    hopsFromSelf: 2, isSelf: false, myHardIfname: 'vxlan0', secondaryMacs: [] },
@@ -120,7 +120,7 @@ describe('TestHostRecords', () => {
   it('self.interfaces rolls up the set of my hard ifnames', () => {
     const v = buildTopologyView(localAndRemote());
     const names = v.self.interfaces.map((i) => i.name).sort();
-    expect(names).toEqual(['vxlan0', 'wlan0']);
+    expect(names).toEqual(['vxlan0', 'wlh0']);
     const vxlan = v.self.interfaces.find((i) => i.name === 'vxlan0');
     expect(vxlan.role).toBe('blos');
   });

--- a/frontend/src/__tests__/meshApi.test.js
+++ b/frontend/src/__tests__/meshApi.test.js
@@ -61,7 +61,7 @@ describe('TestFetchMeshStatus', () => {
         listWirelessInterfaces() {
           return {
             interfaces: [{
-              name: 'wlan0',
+              name: 'wlh0',
               interfaceType: 'mesh',
               frequency: 5180,
               channelWidth: 80,
@@ -85,7 +85,7 @@ describe('TestFetchMeshStatus', () => {
       name: 'node2', mac: 'aa:bb:cc:dd:ee:ff', signal: -50, throughput: 100,
     }]);
     expect(result.interfaces).toEqual([{
-      name: 'wlan0', type: 'mesh', frequency: 5180, channel_width: 80,
+      name: 'wlh0', type: 'mesh', frequency: 5180, channel_width: 80,
     }]);
   });
 

--- a/internal/batman-adv/gateway_config_test.go
+++ b/internal/batman-adv/gateway_config_test.go
@@ -11,7 +11,7 @@ func mockGatewaysJSON() string {
 	return `[
   {
     "hard_ifindex": 3,
-    "hard_ifname": "wlan0",
+    "hard_ifname": "wlh0",
     "orig_address": "aa:bb:cc:dd:ee:01",
     "best": true,
     "throughput": 10000,
@@ -21,7 +21,7 @@ func mockGatewaysJSON() string {
   },
   {
     "hard_ifindex": 4,
-    "hard_ifname": "wlan1",
+    "hard_ifname": "wlh1",
     "orig_address": "aa:bb:cc:dd:ee:02",
     "best": false,
     "throughput": 5000,
@@ -31,7 +31,7 @@ func mockGatewaysJSON() string {
   },
   {
     "hard_ifindex": 3,
-    "hard_ifname": "wlan0",
+    "hard_ifname": "wlh0",
     "orig_address": "aa:bb:cc:dd:ee:03",
     "best": false,
     "throughput": 7500,
@@ -191,7 +191,7 @@ func TestFindByInterface(t *testing.T) {
 		{
 			name:     "found",
 			gateways: gateways,
-			ifname:   "wlan1",
+			ifname:   "wlh1",
 			wantNil:  false,
 		},
 		{
@@ -203,7 +203,7 @@ func TestFindByInterface(t *testing.T) {
 		{
 			name:     "nil gateways",
 			gateways: nil,
-			ifname:   "wlan0",
+			ifname:   "wlh0",
 			wantNil:  true,
 		},
 	}
@@ -240,13 +240,13 @@ func TestFilterByInterface(t *testing.T) {
 		{
 			name:      "multiple matches",
 			gateways:  gateways,
-			ifname:    "wlan0",
+			ifname:    "wlh0",
 			wantCount: 2,
 		},
 		{
 			name:      "single match",
 			gateways:  gateways,
-			ifname:    "wlan1",
+			ifname:    "wlh1",
 			wantCount: 1,
 		},
 		{
@@ -258,7 +258,7 @@ func TestFilterByInterface(t *testing.T) {
 		{
 			name:      "nil gateways",
 			gateways:  nil,
-			ifname:    "wlan0",
+			ifname:    "wlh0",
 			wantCount: 0,
 		},
 	}
@@ -505,7 +505,7 @@ func TestGetInterfaces(t *testing.T) {
 		t.Errorf("GetInterfaces() returned %d interfaces, want 2", len(interfaces))
 	}
 
-	expected := []string{"wlan0", "wlan1"}
+	expected := []string{"wlh0", "wlh1"}
 	if !reflect.DeepEqual(interfaces, expected) {
 		t.Errorf("GetInterfaces() = %v, want %v", interfaces, expected)
 	}

--- a/internal/batman-adv/mesh_config_test.go
+++ b/internal/batman-adv/mesh_config_test.go
@@ -15,7 +15,7 @@ func mockBatctlOutput() string {
   "mesh_ifname": "bat0",
   "mesh_address": "02:00:00:00:00:01",
   "hard_ifindex": 3,
-  "hard_ifname": "wlan0",
+  "hard_ifname": "wlh0",
   "hard_address": "aa:bb:cc:dd:ee:ff",
   "tt_ttvn": 42,
   "bla_crc": 12345,

--- a/internal/batman-adv/mesh_neighbors_snapshot_test.go
+++ b/internal/batman-adv/mesh_neighbors_snapshot_test.go
@@ -61,7 +61,7 @@ func makePayloadWithHostname(t *testing.T, primary, hostname string, collected t
 		Algorithm:   15,
 		CollectedAt: timestamppb.New(collected),
 		Neighbors: []*netv1.MeshNeighbor{
-			{Mac: "aa:bb:cc:dd:ee:ff", HardIfname: "wlan0", Blos: false, ThroughputKbps: 50000},
+			{Mac: "aa:bb:cc:dd:ee:ff", HardIfname: "wlh0", Blos: false, ThroughputKbps: 50000},
 		},
 	}
 
@@ -575,7 +575,7 @@ func TestMeshNeighborsSnapshotter_SamePublisherDualChannelDoesNotWarn(t *testing
 
 	const (
 		sharedPrimary = "0a:d7:37:78:2d:3e" // BCM2711-97d6's bat0 MAC
-		ifaceMAC      = "3c:22:7f:37:4c:0c" // BCM2711-97d6's wlan0 MAC
+		ifaceMAC      = "3c:22:7f:37:4c:0c" // BCM2711-97d6's wlh0 MAC
 		// Two different alfred envelopes — one per batman-adv instance.
 		channelARFEnv  = "f2:f9:81:82:98:73"
 		channelBLOSEnv = "f2:48:e8:f5:70:f2"

--- a/internal/batman-adv/neighbor_config_test.go
+++ b/internal/batman-adv/neighbor_config_test.go
@@ -25,7 +25,7 @@ func mockNeighborsJSON() string {
   },
   {
     "hard_ifindex": 11,
-    "hard_ifname": "wlan0",
+    "hard_ifname": "wlh0",
     "last_seen_msecs": 70,
     "neigh_address": "bc:2a:33:96:b1:84",
     "throughput": 7100
@@ -76,8 +76,8 @@ func TestGetMeshNeighbors_Unmarshal(t *testing.T) {
 	}
 
 	// Verify third neighbor is on different interface
-	if neighbors[2].HardIfname != "wlan0" {
-		t.Errorf("Expected hard_ifname 'wlan0', got '%s'", neighbors[2].HardIfname)
+	if neighbors[2].HardIfname != "wlh0" {
+		t.Errorf("Expected hard_ifname 'wlh0', got '%s'", neighbors[2].HardIfname)
 	}
 }
 
@@ -154,7 +154,7 @@ func TestNeighbors_FilterByInterface(t *testing.T) {
 		{
 			name:      "single match",
 			neighbors: neighbors,
-			ifname:    "wlan0",
+			ifname:    "wlh0",
 			wantCount: 1,
 		},
 		{
@@ -281,7 +281,7 @@ func TestNeighbors_GetInterfaces(t *testing.T) {
 		t.Errorf("GetInterfaces() returned %d interfaces, want 2", len(interfaces))
 	}
 
-	expected := []string{"phy1-mesh0", "wlan0"}
+	expected := []string{"phy1-mesh0", "wlh0"}
 	if !reflect.DeepEqual(interfaces, expected) {
 		t.Errorf("GetInterfaces() = %v, want %v", interfaces, expected)
 	}

--- a/internal/batman-adv/neighbors_test.go
+++ b/internal/batman-adv/neighbors_test.go
@@ -36,7 +36,7 @@ func TestParseBatHostsFile(t *testing.T) {
 
 	// Verify a specific host entry
 	expectedMAC := "3c:22:7f:37:4c:0c"
-	expectedHostname := "BCM2711-97d6_wlan0"
+	expectedHostname := "BCM2711-97d6_wlh0"
 	found := false
 
 	for _, host := range node1.Hosts {
@@ -112,11 +112,11 @@ func TestGetHostByMAC(t *testing.T) {
 		mac      string
 		expected string
 	}{
-		{"3c:22:7f:37:4c:0c", "BCM2711-97d6_wlan0"},
+		{"3c:22:7f:37:4c:0c", "BCM2711-97d6_wlh0"},
 		{"9c:ef:d5:f9:80:4d", "BCM2711-97d6_phy2-mesh0"},
-		{"bc:2a:33:96:b1:84", "BCM2711-88ba_wlan0"},
+		{"bc:2a:33:96:b1:84", "BCM2711-88ba_wlh0"},
 		{"00:c0:ca:b6:5c:58", "HaLow-R-b65c57_mesh0"},
-		{"e4:5f:01:df:f8:fe", "BCM2711-f8fd_wlan-f8-fe"},
+		{"e4:5f:01:df:f8:fe", "BCM2711-f8fd_wlh-f8-fe"},
 		{"00:00:00:00:00:00", ""}, // Non-existent MAC
 	}
 
@@ -142,7 +142,7 @@ func TestGetHostByMAC_CaseInsensitive(t *testing.T) {
 	hostname1 := batHosts.GetHostByMAC("3c:22:7f:37:4c:0c")
 	hostname2 := batHosts.GetHostByMAC("3C:22:7F:37:4C:0C")
 
-	if hostname1 != hostname2 || hostname1 != "BCM2711-97d6_wlan0" {
+	if hostname1 != hostname2 || hostname1 != "BCM2711-97d6_wlh0" {
 		t.Errorf("Case insensitive lookup failed: %s vs %s", hostname1, hostname2)
 	}
 }

--- a/internal/batman-adv/normalize_test.go
+++ b/internal/batman-adv/normalize_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestParseOriginators_LowercasesMACs(t *testing.T) {
 	raw := []byte(`[
-		{"orig_address":"AA:BB:CC:DD:EE:01","best_next_hop":"AA:BB:CC:DD:EE:02","hard_ifname":"wlan0","tq":255,"best":true},
-		{"orig_address":"aa:BB:cc:DD:ee:03","best_next_hop":"AA:bb:CC:dd:EE:01","hard_ifname":"wlan0","tq":200,"best":false}
+		{"orig_address":"AA:BB:CC:DD:EE:01","best_next_hop":"AA:BB:CC:DD:EE:02","hard_ifname":"wlh0","tq":255,"best":true},
+		{"orig_address":"aa:BB:cc:DD:ee:03","best_next_hop":"AA:bb:CC:dd:EE:01","hard_ifname":"wlh0","tq":200,"best":false}
 	]`)
 
 	origs, err := parseOriginators(raw)
@@ -45,8 +45,8 @@ func TestParseOriginators_PreservesOtherFields(t *testing.T) {
 
 func TestParseGateways_LowercasesMACs(t *testing.T) {
 	raw := []byte(`[
-		{"orig_address":"AA:BB:CC:DD:EE:01","router":"AA:BB:CC:DD:EE:02","hard_ifname":"wlan0","best":true},
-		{"orig_address":"11:22:33:44:55:66","router":"77:88:99:AA:BB:CC","hard_ifname":"wlan0"}
+		{"orig_address":"AA:BB:CC:DD:EE:01","router":"AA:BB:CC:DD:EE:02","hard_ifname":"wlh0","best":true},
+		{"orig_address":"11:22:33:44:55:66","router":"77:88:99:AA:BB:CC","hard_ifname":"wlh0"}
 	]`)
 
 	gws, err := parseGateways(raw)
@@ -62,8 +62,8 @@ func TestParseGateways_LowercasesMACs(t *testing.T) {
 
 func TestParseNeighbors_LowercasesMACs(t *testing.T) {
 	raw := []byte(`[
-		{"neigh_address":"AA:BB:CC:DD:EE:01","hard_ifname":"wlan0","last_seen_msecs":100,"throughput":50},
-		{"neigh_address":"aa:BB:cc:DD:ee:02","hard_ifname":"wlan0","last_seen_msecs":200,"throughput":30}
+		{"neigh_address":"AA:BB:CC:DD:EE:01","hard_ifname":"wlh0","last_seen_msecs":100,"throughput":50},
+		{"neigh_address":"aa:BB:cc:DD:ee:02","hard_ifname":"wlh0","last_seen_msecs":200,"throughput":30}
 	]`)
 
 	neighs, err := parseNeighbors(raw)

--- a/internal/batman-adv/originator_topology.go
+++ b/internal/batman-adv/originator_topology.go
@@ -41,7 +41,7 @@ type OriginatorEntry struct {
 	OrigHostname    string // from bat-hosts; empty if unknown
 	NextHopMAC      string
 	NextHopHostname string // from bat-hosts; empty if unknown
-	HardIfname      string // wlan0, phy2-mesh0, vxlan0, …
+	HardIfname      string // wlh0, phy2-mesh0, vxlan0, …
 	TQ              int
 	Throughput      float64
 	LastSeenMs      int

--- a/internal/batman-adv/originator_topology_test.go
+++ b/internal/batman-adv/originator_topology_test.go
@@ -136,7 +136,7 @@ func TestGetOriginatorTopology_AlgorithmBATMANIV(t *testing.T) {
 // values are present (the BATMAN_V case operators see on newer kernels).
 func TestGetOriginatorTopology_AlgorithmBATMANV(t *testing.T) {
 	rows := []batmanadv.Originator{
-		{OrigAddress: "aa:bb:cc:dd:ee:01", HardIfname: "wlan0", BestNeigh: "aa:bb:cc:dd:ee:01", Throughput: 150000, Best: true},
+		{OrigAddress: "aa:bb:cc:dd:ee:01", HardIfname: "wlh0", BestNeigh: "aa:bb:cc:dd:ee:01", Throughput: 150000, Best: true},
 	}
 	p := newProvider(rows, "0a:d7:37:78:2d:3e")
 
@@ -209,8 +209,8 @@ func TestGetOriginatorTopology_ProviderError(t *testing.T) {
 // looping forever if the originator table ever reports a cycle.
 func TestGetOriginatorTopology_CycleSafety(t *testing.T) {
 	rows := []batmanadv.Originator{
-		{OrigAddress: "aa:01", HardIfname: "wlan0", BestNeigh: "aa:02", TQ: 200, Best: true},
-		{OrigAddress: "aa:02", HardIfname: "wlan0", BestNeigh: "aa:01", TQ: 200, Best: true},
+		{OrigAddress: "aa:01", HardIfname: "wlh0", BestNeigh: "aa:02", TQ: 200, Best: true},
+		{OrigAddress: "aa:02", HardIfname: "wlh0", BestNeigh: "aa:01", TQ: 200, Best: true},
 	}
 	p := newProvider(rows, "")
 

--- a/internal/comms/README.md
+++ b/internal/comms/README.md
@@ -625,6 +625,19 @@ malgo selects the correct sound card. If `ALSA_CARD` is already set, it
 is left unchanged. A fallback path scans `/proc/asound/card*/usbid` for
 `0d8c:0012` when sysfs discovery fails.
 
+### Audio init retry and in-run recovery
+
+Hardware audio init is retried up to 3 times at startup (750 ms apart,
+context-aware) to absorb transient ALSA/USB failures while the OpenVLM
+dongle settles after boot-time enumeration (observed as `miniaudio:
+Broken pipe` from the dmix slave start). If all startup attempts fail,
+comms stays up (RTP relay and WebUI toggles keep working) and the Run
+loop re-attempts init every 10 seconds — including re-running ALSA card
+detection when `ALSA_CARD` is still unset — so plugging the dongle in
+later brings local mic/speaker up without a daemon restart. Both log
+paths carry an `alsa_card` field naming the card index the `default`
+ALSA PCM resolves to.
+
 `PTTDown` → `beginTransmission`; `PTTUp` → `endTransmission`.
 
 ### `roip` backend

--- a/internal/comms/audio/encoder.go
+++ b/internal/comms/audio/encoder.go
@@ -139,7 +139,7 @@ type BroadcastEncoder struct {
 }
 
 // Compile-time assertion: BroadcastEncoder satisfies device.AudioStream so
-// the parent's CommsRuntime.BroadcastStream field accepts it directly.
+// it can be installed via the parent's CommsRuntime.SetBroadcast accessor.
 var _ device.AudioStream = (*BroadcastEncoder)(nil)
 
 // NewBroadcastEncoder constructs the wrapper, opens the capture stream

--- a/internal/comms/audio/init.go
+++ b/internal/comms/audio/init.go
@@ -306,7 +306,7 @@ func computePlaybackPeriodFrames(latencyMs int) int {
 // per-port playback streams, starts them (always-on capture + playback),
 // and returns a cleanup function that stops and closes them. The
 // returned BroadcastEncoder is the same instance the parent runtime
-// should treat as its CommsRuntime.BroadcastStream.
+// should install via CommsRuntime.SetBroadcast.
 func (in *Init) StartHardware(slots []PortSlot) (broadcast *BroadcastEncoder, cleanup func(), err error) {
 	logProc := func(message string) {
 		// miniaudio emits transient ALSA recovery noise during USB audio

--- a/internal/comms/audio/init.go
+++ b/internal/comms/audio/init.go
@@ -49,7 +49,9 @@ func (in *Init) BuildAudio(slots []PortSlot) (*BroadcastEncoder, device.AudioDev
 		return nil, zeroIn, err
 	}
 
-	in.Log.Info().Msgf("comms: audio in=%s out=%s", inDev.Name, outDev.Name)
+	in.Log.Info().
+		Str("alsa_card", os.Getenv("ALSA_CARD")).
+		Msgf("comms: audio in=%s out=%s", inDev.Name, outDev.Name)
 
 	playbackPeriod := uint32(computePlaybackPeriodFrames(in.PlaybackLatencyMs))
 

--- a/internal/comms/config.go
+++ b/internal/comms/config.go
@@ -107,7 +107,10 @@ type CommsConfig struct {
 	AuxHandler           control.AuxEventHandler
 	Interrupt            chan os.Signal
 	startHardwareAudioFn func(rt *CommsRuntime) (func(), error)
-	audioInitRetryDelay  time.Duration
+	// detectALSACardFn overrides ALSA card auto-detection for tests. When
+	// nil, detectALSACard falls back to control.DetectAndSetALSACard(cfg.Log).
+	detectALSACardFn    func()
+	audioInitRetryDelay time.Duration
 	// audioRecoveryInterval is the Run-loop ticker period for re-attempting
 	// hardware audio init after startup failed (OpenVLM unplugged at boot,
 	// transient ALSA error). <= 0 disables in-run recovery; applyDefaults

--- a/internal/comms/config.go
+++ b/internal/comms/config.go
@@ -74,6 +74,7 @@ type CommsConfig struct {
 	AuxHandler               control.AuxEventHandler
 	Interrupt                chan os.Signal
 	startHardwareAudioFn     func(rt *CommsRuntime) (func(), error)
+	audioInitRetryDelay      time.Duration
 	CommKey                  string
 	BluetoothInputDevice     string
 	Iface                    string
@@ -216,5 +217,9 @@ func (cfg *CommsConfig) applyDefaults() {
 		if cfg.BluetoothOutputDevice == "" {
 			cfg.BluetoothOutputDevice = cfg.BluetoothAudioDeviceHint
 		}
+	}
+
+	if cfg.audioInitRetryDelay == 0 {
+		cfg.audioInitRetryDelay = defaultAudioInitRetryDelay
 	}
 }

--- a/internal/comms/config.go
+++ b/internal/comms/config.go
@@ -2,6 +2,7 @@ package comms
 
 import (
 	"os"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -40,7 +41,6 @@ type BroadcastCapture interface {
 type CommsRuntime struct {
 	Decoder         codec.AudioDecoder
 	Encoder         codec.AudioEncoder
-	BroadcastStream BroadcastCapture
 	FECAdapter      *FECAdapter
 	WebBridge       *webaudio.Bridge
 	WebEvtSrc       *control.WebEventSource
@@ -58,6 +58,32 @@ type CommsRuntime struct {
 	PlaybackOutputLatency time.Duration
 	Broadcasting          atomic.Bool
 	RemoteRxActive        atomic.Bool
+
+	// mu protects broadcastStream. It is written at startup by
+	// initAudioIO/startHardwareAudio and again by the Run loop's audio
+	// recovery path; it is read from the Run goroutine (transmit paths)
+	// and from the instrumentation snapshot goroutine, so a plain field
+	// is not enough once recovery can install it mid-run.
+	mu              sync.RWMutex
+	broadcastStream BroadcastCapture
+}
+
+// Broadcast returns the live capture stream, or nil when hardware audio is
+// not (yet) up. Reads outnumber writes by orders of magnitude, hence RWMutex.
+func (rt *CommsRuntime) Broadcast() BroadcastCapture {
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+
+	return rt.broadcastStream
+}
+
+// SetBroadcast installs the capture stream produced by a successful
+// hardware audio init (startup or in-run recovery).
+func (rt *CommsRuntime) SetBroadcast(bs BroadcastCapture) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	rt.broadcastStream = bs
 }
 
 // ─── CommsConfig ──────────────────────────────────────────────────────────────

--- a/internal/comms/config.go
+++ b/internal/comms/config.go
@@ -66,6 +66,13 @@ type CommsRuntime struct {
 	// is not enough once recovery can install it mid-run.
 	mu              sync.RWMutex
 	broadcastStream BroadcastCapture
+
+	// audioCleanup is the malgo teardown produced by a successful hardware
+	// audio init. Written by Start (startup path) and by the Run loop's
+	// recovery path, read by Start's deferred teardown after Run returns.
+	// Run executes synchronously on the Start goroutine, so all accesses
+	// are sequential and no lock is needed.
+	audioCleanup func()
 }
 
 // Broadcast returns the live capture stream, or nil when hardware audio is
@@ -96,11 +103,16 @@ func (rt *CommsRuntime) SetBroadcast(bs BroadcastCapture) {
 // owned by *Service (returned by Start via SetDefault) so the static
 // config and the per-startup runtime have distinct lifetimes.
 type CommsConfig struct {
-	Log                      zerolog.Logger
-	AuxHandler               control.AuxEventHandler
-	Interrupt                chan os.Signal
-	startHardwareAudioFn     func(rt *CommsRuntime) (func(), error)
-	audioInitRetryDelay      time.Duration
+	Log                  zerolog.Logger
+	AuxHandler           control.AuxEventHandler
+	Interrupt            chan os.Signal
+	startHardwareAudioFn func(rt *CommsRuntime) (func(), error)
+	audioInitRetryDelay  time.Duration
+	// audioRecoveryInterval is the Run-loop ticker period for re-attempting
+	// hardware audio init after startup failed (OpenVLM unplugged at boot,
+	// transient ALSA error). <= 0 disables in-run recovery; applyDefaults
+	// sets the production value.
+	audioRecoveryInterval    time.Duration
 	CommKey                  string
 	BluetoothInputDevice     string
 	Iface                    string
@@ -247,5 +259,9 @@ func (cfg *CommsConfig) applyDefaults() {
 
 	if cfg.audioInitRetryDelay == 0 {
 		cfg.audioInitRetryDelay = defaultAudioInitRetryDelay
+	}
+
+	if cfg.audioRecoveryInterval == 0 {
+		cfg.audioRecoveryInterval = defaultAudioRecoveryInterval
 	}
 }

--- a/internal/comms/config.go
+++ b/internal/comms/config.go
@@ -38,7 +38,7 @@ type BroadcastCapture interface {
 // packet from a send-enabled port (no false negatives at the start of an
 // incoming stream) and cleared by halfDuplexDecayLoop on a coarse 100 ms
 // ticker once every gate's window has expired.
-type CommsRuntime struct {
+type CommsRuntime struct { //nolint:govet // fieldalignment: mu must sit directly above the broadcastStream field it guards (.claude/rules/concurrency.md); the pointer-scan-optimal layout would separate them.
 	Decoder         codec.AudioDecoder
 	Encoder         codec.AudioEncoder
 	FECAdapter      *FECAdapter
@@ -109,13 +109,9 @@ type CommsConfig struct {
 	startHardwareAudioFn func(rt *CommsRuntime) (func(), error)
 	// detectALSACardFn overrides ALSA card auto-detection for tests. When
 	// nil, detectALSACard falls back to control.DetectAndSetALSACard(cfg.Log).
-	detectALSACardFn    func()
-	audioInitRetryDelay time.Duration
-	// audioRecoveryInterval is the Run-loop ticker period for re-attempting
-	// hardware audio init after startup failed (OpenVLM unplugged at boot,
-	// transient ALSA error). <= 0 disables in-run recovery; applyDefaults
-	// sets the production value.
-	audioRecoveryInterval    time.Duration
+	detectALSACardFn         func()
+	BluetoothOutputDevice    string
+	NanoPTTDevicePath        string
 	CommKey                  string
 	BluetoothInputDevice     string
 	Iface                    string
@@ -123,27 +119,31 @@ type CommsConfig struct {
 	ControlSource            string
 	NanoPTTDeviceName        string
 	RtpID                    string
-	NanoPTTDevicePath        string
-	BluetoothOutputDevice    string
 	McastPorts               []McastPortConfig
+	HalfDuplexThreshold      time.Duration
+	audioInitRetryDelay      time.Duration
 	ROIPMaxTXDuration        time.Duration
 	ROIPVOXHoldTime          time.Duration
 	EncoderComplexity        int
 	PttStartDelayMs          int
 	CaptureFramesPerBuffer   int
 	CaptureLatencyMs         int
-	PlaybackLatencyMs        int
 	PacketLossPerc           int
-	HalfDuplexThreshold      time.Duration
-	ROIPVOXThreshold         float32
-	MicGain                  float32
-	EnableNanoPTT            bool
-	EnableBluetoothPtt       bool
-	Enable                   bool
-	Trace                    bool
-	Loopback                 bool
-	Debug                    bool
-	ROIPCOSGPIOMask          byte
+	PlaybackLatencyMs        int
+	// audioRecoveryInterval is the Run-loop ticker period for re-attempting
+	// hardware audio init after startup failed (OpenVLM unplugged at boot,
+	// transient ALSA error). <= 0 disables in-run recovery; applyDefaults
+	// sets the production value.
+	audioRecoveryInterval time.Duration
+	ROIPVOXThreshold      float32
+	MicGain               float32
+	EnableNanoPTT         bool
+	EnableBluetoothPtt    bool
+	Enable                bool
+	Trace                 bool
+	Loopback              bool
+	Debug                 bool
+	ROIPCOSGPIOMask       byte
 }
 
 // NewComms copies cfg and returns a pointer ready for Start.

--- a/internal/comms/lifecycle.go
+++ b/internal/comms/lifecycle.go
@@ -74,7 +74,7 @@ func (cfg *CommsConfig) startHardwareAudio(rt *CommsRuntime) (cleanup func(), er
 		return nil, hwErr
 	}
 
-	rt.BroadcastStream = broadcast
+	rt.SetBroadcast(broadcast)
 	rt.PlaybackOutputLatency = audioInit.PlaybackOutputLatency
 
 	return cleanup, nil

--- a/internal/comms/lifecycle.go
+++ b/internal/comms/lifecycle.go
@@ -91,6 +91,11 @@ const (
 	// defaultAudioInitRetryDelay is the production wait between startup
 	// attempts; applyDefaults installs it when the field is zero.
 	defaultAudioInitRetryDelay = 750 * time.Millisecond
+
+	// defaultAudioRecoveryInterval paces in-run hardware audio recovery
+	// attempts. Slow enough that a permanently absent dongle costs nothing
+	// measurable, fast enough that plugging one in feels immediate.
+	defaultAudioRecoveryInterval = 10 * time.Second
 )
 
 // initAudioIO wires up the local audio path for cfg.ControlSource. In web
@@ -171,6 +176,37 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 	case <-t.C:
 		return true
 	}
+}
+
+// tryAudioRecovery performs one in-run hardware audio init attempt. Called
+// only from the Run goroutine (ticker case). Re-runs ALSA card detection
+// first when ALSA_CARD is still unset — the OpenVLM may have been plugged
+// in after startup detection ran. Returns true when audio is up.
+func (cfg *CommsConfig) tryAudioRecovery(rt *CommsRuntime) bool {
+	if os.Getenv("ALSA_CARD") == "" &&
+		(cfg.ControlSource == defaultCtrlSrc || cfg.ControlSource == controlSourceROIP) {
+		control.DetectAndSetALSACard(cfg.Log)
+	}
+
+	startHA := cfg.startHardwareAudioFn
+	if startHA == nil {
+		startHA = cfg.startHardwareAudio
+	}
+
+	cleanup, err := startHA(rt)
+	if err != nil {
+		cfg.Log.Warn().Err(err).
+			Dur("retry_in", cfg.audioRecoveryInterval).
+			Msg("comms: audio recovery attempt failed")
+
+		return false
+	}
+
+	rt.audioCleanup = cleanup
+
+	cfg.Log.Info().Msg("comms: hardware audio recovered")
+
+	return true
 }
 
 // Start initializes all comms subsystems and blocks until ctx is canceled.
@@ -281,9 +317,13 @@ func (cfg *CommsConfig) Start(ctx context.Context) error {
 	}
 
 	// ── audio I/O ─────────────────────────────────────────────────────────
-	if cleanup := cfg.initAudioIO(ctx, rt); cleanup != nil {
-		defer cleanup()
-	}
+	rt.audioCleanup = cfg.initAudioIO(ctx, rt)
+
+	defer func() {
+		if rt.audioCleanup != nil {
+			rt.audioCleanup()
+		}
+	}()
 
 	// ── run loop ───────────────────────────────────────────────────────────
 	cfg.Run(ctx, rt, src)

--- a/internal/comms/lifecycle.go
+++ b/internal/comms/lifecycle.go
@@ -96,6 +96,16 @@ const (
 	// attempts. Slow enough that a permanently absent dongle costs nothing
 	// measurable, fast enough that plugging one in feels immediate.
 	defaultAudioRecoveryInterval = 10 * time.Second
+
+	// recoveryDetectEveryNth bounds how often tryAudioRecovery re-runs ALSA
+	// card detection once the first attempt has already run it once. At
+	// the default 10s audioRecoveryInterval this is roughly once a minute.
+	// Detection itself logs a Warn on every miss (openvlm.go), so re-running
+	// it every tick on a permanently dongle-less device would flood logd;
+	// bounding the re-run rate keeps that noise in check without disabling
+	// detection outright (a dongle plugged in after startup still gets
+	// picked up within a minute).
+	recoveryDetectEveryNth = 6
 )
 
 // initAudioIO wires up the local audio path for cfg.ControlSource. In web
@@ -179,13 +189,25 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 }
 
 // tryAudioRecovery performs one in-run hardware audio init attempt. Called
-// only from the Run goroutine (ticker case). Re-runs ALSA card detection
-// first when ALSA_CARD is still unset — the OpenVLM may have been plugged
-// in after startup detection ran. Returns true when audio is up.
-func (cfg *CommsConfig) tryAudioRecovery(rt *CommsRuntime) bool {
+// only from the Run goroutine (ticker case) with a monotonically increasing
+// attempt counter local to that goroutine — never accessed concurrently, so
+// it needs no synchronization of its own.
+//
+// Re-runs ALSA card detection when ALSA_CARD is still unset — the OpenVLM
+// may have been plugged in after startup detection ran — but only on the
+// first attempt and every recoveryDetectEveryNth attempt thereafter (see
+// its doc comment): detection logs its own Warn on every miss, and running
+// it on every 10s tick forever on a dongle-less device floods logd.
+//
+// Failure logging is similarly throttled: the first failed attempt logs at
+// Warn (so the operator sees the daemon is degraded), every subsequent
+// consecutive failure logs at Debug so a permanently absent dongle doesn't
+// produce ~17k Warn lines/day. Returns true when audio is up.
+func (cfg *CommsConfig) tryAudioRecovery(rt *CommsRuntime, attempt int) bool {
 	if os.Getenv("ALSA_CARD") == "" &&
-		(cfg.ControlSource == defaultCtrlSrc || cfg.ControlSource == controlSourceROIP) {
-		control.DetectAndSetALSACard(cfg.Log)
+		(cfg.ControlSource == defaultCtrlSrc || cfg.ControlSource == controlSourceROIP) &&
+		(attempt == 1 || attempt%recoveryDetectEveryNth == 0) {
+		cfg.detectALSACard()
 	}
 
 	startHA := cfg.startHardwareAudioFn
@@ -195,7 +217,13 @@ func (cfg *CommsConfig) tryAudioRecovery(rt *CommsRuntime) bool {
 
 	cleanup, err := startHA(rt)
 	if err != nil {
-		cfg.Log.Warn().Err(err).
+		logEvent := cfg.Log.Debug()
+		if attempt == 1 {
+			logEvent = cfg.Log.Warn()
+		}
+
+		logEvent.Err(err).
+			Int("attempt", attempt).
 			Dur("retry_in", cfg.audioRecoveryInterval).
 			Msg("comms: audio recovery attempt failed")
 
@@ -207,6 +235,20 @@ func (cfg *CommsConfig) tryAudioRecovery(rt *CommsRuntime) bool {
 	cfg.Log.Info().Msg("comms: hardware audio recovered")
 
 	return true
+}
+
+// detectALSACard runs ALSA card auto-detection through cfg.detectALSACardFn
+// when set (test seam), falling back to the real
+// control.DetectAndSetALSACard otherwise. Follows the same override pattern
+// as startHardwareAudio/startHardwareAudioFn.
+func (cfg *CommsConfig) detectALSACard() {
+	if cfg.detectALSACardFn != nil {
+		cfg.detectALSACardFn()
+
+		return
+	}
+
+	control.DetectAndSetALSACard(cfg.Log)
 }
 
 // Start initializes all comms subsystems and blocks until ctx is canceled.

--- a/internal/comms/lifecycle.go
+++ b/internal/comms/lifecycle.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -78,18 +80,33 @@ func (cfg *CommsConfig) startHardwareAudio(rt *CommsRuntime) (cleanup func(), er
 	return cleanup, nil
 }
 
+const (
+	// audioInitAttempts bounds the startup hardware-audio init retries.
+	// The OpenVLM dongle can transiently fail its first dmix slave start
+	// while USB enumeration settles at boot (EPIPE from snd_pcm_start);
+	// a couple of spaced retries absorbs that without delaying startup
+	// noticeably.
+	audioInitAttempts = 3
+
+	// defaultAudioInitRetryDelay is the production wait between startup
+	// attempts; applyDefaults installs it when the field is zero.
+	defaultAudioInitRetryDelay = 750 * time.Millisecond
+)
+
 // initAudioIO wires up the local audio path for cfg.ControlSource. In web
 // mode it constructs a webaudio bridge; in non-web modes (openvlm, nanoptt,
-// roip) it tries to open the malgo capture/playback streams.
+// roip) it tries to open the malgo capture/playback streams, retrying up to
+// audioInitAttempts times with cfg.audioInitRetryDelay between attempts.
 //
 // A failure to bring up local audio is non-fatal: the comms subsystem stays
 // alive so RTP relay between mesh peers continues, and the WebUI's
 // per-channel RX/TX toggles still take effect. The TX/RX hot paths already
-// guard against the resulting nil BroadcastStream / PlaybackStream.
+// guard against the resulting nil BroadcastStream / PlaybackStream. The Run
+// loop's audio recovery ticker keeps re-attempting init in the background.
 //
 // Returns the malgo cleanup function (nil when there is nothing to clean
 // up) so Start can defer it.
-func (cfg *CommsConfig) initAudioIO(rt *CommsRuntime) func() {
+func (cfg *CommsConfig) initAudioIO(ctx context.Context, rt *CommsRuntime) func() {
 	if cfg.ControlSource == controlSourceWeb {
 		// Web mode: skip the malgo pipeline entirely; the browser provides audio I/O.
 		rt.WebBridge = webaudio.NewBridge(cfg.Log, func(payload []byte) {
@@ -104,14 +121,56 @@ func (cfg *CommsConfig) initAudioIO(rt *CommsRuntime) func() {
 		startHA = cfg.startHardwareAudio
 	}
 
-	cleanup, hwErr := startHA(rt)
-	if hwErr != nil {
-		cfg.Log.Error().Err(hwErr).Msg("comms: hardware audio init failed; continuing without local mic/speaker")
+	var lastErr error
 
-		return nil
+	for attempt := 1; attempt <= audioInitAttempts; attempt++ {
+		cleanup, hwErr := startHA(rt)
+		if hwErr == nil {
+			if attempt > 1 {
+				cfg.Log.Info().Int("attempt", attempt).Msg("comms: hardware audio init succeeded after retry")
+			}
+
+			return cleanup
+		}
+
+		lastErr = hwErr
+		cfg.Log.Warn().Err(hwErr).
+			Int("attempt", attempt).
+			Int("max_attempts", audioInitAttempts).
+			Msg("comms: hardware audio init attempt failed")
+
+		if attempt == audioInitAttempts {
+			break
+		}
+
+		if !sleepCtx(ctx, cfg.audioInitRetryDelay) {
+			return nil
+		}
 	}
 
-	return cleanup
+	cfg.Log.Error().Err(lastErr).
+		Str("alsa_card", os.Getenv("ALSA_CARD")).
+		Msg("comms: hardware audio init failed; continuing without local mic/speaker")
+
+	return nil
+}
+
+// sleepCtx waits for d or until ctx is canceled. Returns false when the
+// context ended the wait (or was already canceled).
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+
+	t := time.NewTimer(d)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 // Start initializes all comms subsystems and blocks until ctx is canceled.
@@ -222,7 +281,7 @@ func (cfg *CommsConfig) Start(ctx context.Context) error {
 	}
 
 	// ── audio I/O ─────────────────────────────────────────────────────────
-	if cleanup := cfg.initAudioIO(rt); cleanup != nil {
+	if cleanup := cfg.initAudioIO(ctx, rt); cleanup != nil {
 		defer cleanup()
 	}
 

--- a/internal/comms/lifecycle_test.go
+++ b/internal/comms/lifecycle_test.go
@@ -1,6 +1,7 @@
 package comms
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -189,4 +190,28 @@ func TestInitAudioIO_ContextCanceledStopsRetry(t *testing.T) {
 
 	assert.Nil(t, cleanup)
 	assert.Equal(t, 1, calls, "canceled context must stop after the first attempt")
+}
+
+// TestInitAudioIO_FailureLogIncludesALSACard verifies the operator-facing
+// failure log names the ALSA card the daemon targeted — without it, "audio
+// out=Default Audio Device" hides which card dmix actually resolved to.
+func TestInitAudioIO_FailureLogIncludesALSACard(t *testing.T) {
+	t.Setenv("ALSA_CARD", "1")
+
+	var buf bytes.Buffer
+
+	cfg := &CommsConfig{
+		Log:           zerolog.New(&buf),
+		ControlSource: defaultCtrlSrc,
+		startHardwareAudioFn: func(_ *CommsRuntime) (func(), error) {
+			return nil, errors.New("simulated: miniaudio: Broken pipe")
+		},
+	}
+
+	rt := &CommsRuntime{}
+
+	cleanup := cfg.initAudioIO(context.Background(), rt)
+
+	assert.Nil(t, cleanup)
+	assert.Contains(t, buf.String(), `"alsa_card":"1"`)
 }

--- a/internal/comms/lifecycle_test.go
+++ b/internal/comms/lifecycle_test.go
@@ -47,7 +47,7 @@ func TestInitAudioIO_HardwareFailureIsNonFatal(t *testing.T) {
 	cleanup := cfg.initAudioIO(context.Background(), rt)
 
 	assert.Nil(t, cleanup, "audio failure must not return a cleanup func to defer")
-	assert.Nil(t, rt.BroadcastStream, "BroadcastStream must remain nil so transmit.go's nil guards engage")
+	assert.Nil(t, rt.Broadcast(), "BroadcastStream must remain nil so transmit.go's nil guards engage")
 	assert.Nil(t, rt.WebBridge, "WebBridge must stay nil for non-web control sources")
 
 	// Publish the service the same way Start does so Default()/handler paths see it.

--- a/internal/comms/lifecycle_test.go
+++ b/internal/comms/lifecycle_test.go
@@ -1,8 +1,10 @@
 package comms
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +44,7 @@ func TestInitAudioIO_HardwareFailureIsNonFatal(t *testing.T) {
 	rt.Ports[1].SendEnabled.Store(false)
 	rt.Ports[1].ReceiveEnabled.Store(false)
 
-	cleanup := cfg.initAudioIO(rt)
+	cleanup := cfg.initAudioIO(context.Background(), rt)
 
 	assert.Nil(t, cleanup, "audio failure must not return a cleanup func to defer")
 	assert.Nil(t, rt.BroadcastStream, "BroadcastStream must remain nil so transmit.go's nil guards engage")
@@ -79,7 +81,7 @@ func TestInitAudioIO_HardwareSuccessReturnsCleanup(t *testing.T) {
 
 	rt := &CommsRuntime{}
 
-	cleanup := cfg.initAudioIO(rt)
+	cleanup := cfg.initAudioIO(context.Background(), rt)
 	require.NotNil(t, cleanup)
 
 	cleanup()
@@ -103,8 +105,88 @@ func TestInitAudioIO_WebModeBuildsBridge(t *testing.T) {
 
 	rt := &CommsRuntime{}
 
-	cleanup := cfg.initAudioIO(rt)
+	cleanup := cfg.initAudioIO(context.Background(), rt)
 
 	assert.Nil(t, cleanup, "web mode has no malgo lifecycle to clean up")
 	assert.NotNil(t, rt.WebBridge, "web mode must construct a WebBridge")
+}
+
+// TestInitAudioIO_RetriesThenSucceeds verifies the bounded startup retry:
+// a transient ALSA failure (e.g. dmix EPIPE while USB settles at boot) on
+// the first attempts must not permanently disable local audio.
+func TestInitAudioIO_RetriesThenSucceeds(t *testing.T) {
+	calls := 0
+
+	cfg := &CommsConfig{
+		Log:           zerolog.Nop(),
+		ControlSource: defaultCtrlSrc,
+		startHardwareAudioFn: func(_ *CommsRuntime) (func(), error) {
+			calls++
+			if calls < 3 {
+				return nil, errors.New("simulated: miniaudio: Broken pipe")
+			}
+
+			return func() {}, nil
+		},
+	}
+
+	rt := &CommsRuntime{}
+
+	cleanup := cfg.initAudioIO(context.Background(), rt)
+
+	require.NotNil(t, cleanup, "third attempt succeeds; cleanup must be returned")
+	assert.Equal(t, 3, calls)
+}
+
+// TestInitAudioIO_AllAttemptsFail verifies the retry loop is bounded at
+// audioInitAttempts and that exhaustion preserves the existing non-fatal
+// contract (nil cleanup, nil broadcast stream).
+func TestInitAudioIO_AllAttemptsFail(t *testing.T) {
+	calls := 0
+
+	cfg := &CommsConfig{
+		Log:           zerolog.Nop(),
+		ControlSource: defaultCtrlSrc,
+		startHardwareAudioFn: func(_ *CommsRuntime) (func(), error) {
+			calls++
+
+			return nil, errors.New("simulated: persistent failure")
+		},
+	}
+
+	rt := &CommsRuntime{}
+
+	cleanup := cfg.initAudioIO(context.Background(), rt)
+
+	assert.Nil(t, cleanup)
+	assert.Equal(t, audioInitAttempts, calls)
+}
+
+// TestInitAudioIO_ContextCanceledStopsRetry verifies shutdown during the
+// inter-attempt delay aborts immediately instead of finishing the retry
+// budget. The delay is deliberately huge: if cancellation were broken the
+// test would hang and the suite timeout would catch it.
+func TestInitAudioIO_ContextCanceledStopsRetry(t *testing.T) {
+	calls := 0
+
+	cfg := &CommsConfig{
+		Log:                 zerolog.Nop(),
+		ControlSource:       defaultCtrlSrc,
+		audioInitRetryDelay: time.Hour,
+		startHardwareAudioFn: func(_ *CommsRuntime) (func(), error) {
+			calls++
+
+			return nil, errors.New("simulated: failure")
+		},
+	}
+
+	rt := &CommsRuntime{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cleanup := cfg.initAudioIO(ctx, rt)
+
+	assert.Nil(t, cleanup)
+	assert.Equal(t, 1, calls, "canceled context must stop after the first attempt")
 }

--- a/internal/comms/multiport_test.go
+++ b/internal/comms/multiport_test.go
@@ -385,11 +385,11 @@ func TestBeginTransmission_BeepSentToAllPorts(t *testing.T) {
 
 	rt := &CommsRuntime{
 		Ports:           []*PortChannel{pc0, pc1},
-		BroadcastStream: &mockStream{},
 		BeepBufferStart: []int16{100, 200},
 		BeepBufferStop:  []int16{300, 400},
 		Decoder:         &mockDecoder{},
 	}
+	rt.SetBroadcast(&mockStream{})
 
 	cfg := &CommsConfig{Log: zerolog.Nop()}
 	cfg.beginTransmission(rt)

--- a/internal/comms/snapshot.go
+++ b/internal/comms/snapshot.go
@@ -119,7 +119,7 @@ func (s *Service) Snapshot(dst *CommsSnapshot) {
 	// always a *audio.BroadcastEncoder; test fakes may substitute a
 	// minimal stub that does not carry counters. The type assertion falls
 	// back to a zero snapshot in that case.
-	if be, ok := rt.BroadcastStream.(*audio.BroadcastEncoder); ok {
+	if be, ok := rt.Broadcast().(*audio.BroadcastEncoder); ok {
 		be.Snapshot(&dst.BroadcastEncoder)
 	} else {
 		dst.BroadcastEncoder = audio.AudioEncoderSnapshot{}

--- a/internal/comms/transmit.go
+++ b/internal/comms/transmit.go
@@ -241,9 +241,13 @@ func (cfg *CommsConfig) Run(ctx context.Context, rt *CommsRuntime, src control.E
 	// the zero value used by unit tests). recoverC stays nil when disabled;
 	// a receive from a nil channel blocks forever, so the extra case is
 	// inert. Single attempt per tick on this goroutine — bounded by design.
+	// Accepted tradeoff: tryAudioRecovery is not ctx-aware, so ctx
+	// cancellation during an in-flight ALSA open leaves shutdown waiting
+	// behind that one attempt before Run can return.
 	var (
-		recoverC    <-chan time.Time
-		recoverTick *time.Ticker
+		recoverC        <-chan time.Time
+		recoverTick     *time.Ticker
+		recoverAttempts int
 	)
 
 	if cfg.ControlSource != controlSourceWeb && cfg.audioRecoveryInterval > 0 && rt.Broadcast() == nil {
@@ -260,7 +264,9 @@ func (cfg *CommsConfig) Run(ctx context.Context, rt *CommsRuntime, src control.E
 
 			return
 		case <-recoverC:
-			if cfg.tryAudioRecovery(rt) {
+			recoverAttempts++
+
+			if cfg.tryAudioRecovery(rt, recoverAttempts) {
 				recoverTick.Stop()
 
 				recoverC = nil

--- a/internal/comms/transmit.go
+++ b/internal/comms/transmit.go
@@ -235,12 +235,36 @@ func (cfg *CommsConfig) Run(ctx context.Context, rt *CommsRuntime, src control.E
 		go cfg.runAuxPump(ctx, aux)
 	}
 
+	// In-run audio recovery: when hardware audio failed at startup (or the
+	// dongle was absent), periodically re-attempt init. Disabled in web
+	// mode, when audio is already up, or when the interval is unset (<= 0,
+	// the zero value used by unit tests). recoverC stays nil when disabled;
+	// a receive from a nil channel blocks forever, so the extra case is
+	// inert. Single attempt per tick on this goroutine — bounded by design.
+	var (
+		recoverC    <-chan time.Time
+		recoverTick *time.Ticker
+	)
+
+	if cfg.ControlSource != controlSourceWeb && cfg.audioRecoveryInterval > 0 && rt.Broadcast() == nil {
+		recoverTick = time.NewTicker(cfg.audioRecoveryInterval)
+		defer recoverTick.Stop()
+
+		recoverC = recoverTick.C
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			cfg.Log.Info().Msg("comms context canceled; exiting run loop")
 
 			return
+		case <-recoverC:
+			if cfg.tryAudioRecovery(rt) {
+				recoverTick.Stop()
+
+				recoverC = nil
+			}
 		case ev, ok := <-events:
 			if !ok {
 				return

--- a/internal/comms/transmit.go
+++ b/internal/comms/transmit.go
@@ -162,14 +162,15 @@ func (cfg *CommsConfig) beginTransmission(rt *CommsRuntime) {
 		time.Sleep(d)
 	}
 
-	if rt.BroadcastStream == nil {
+	bs := rt.Broadcast()
+	if bs == nil {
 		cfg.Log.Error().Msg("BroadcastStream is nil; cannot begin transmission")
 		rt.Broadcasting.Store(false)
 
 		return
 	}
 
-	rt.BroadcastStream.SetTxEnabled(true)
+	bs.SetTxEnabled(true)
 
 	cfg.Log.Debug().Msg("TX gate opened")
 }
@@ -194,10 +195,10 @@ func (cfg *CommsConfig) endTransmission(rt *CommsRuntime) {
 
 	cfg.Log.Debug().Msg("End transmission: closing TX gate and playing stop tone")
 
-	if rt.BroadcastStream == nil {
+	if bs := rt.Broadcast(); bs == nil {
 		cfg.Log.Warn().Msg("BroadcastStream was nil during end transmission")
 	} else {
-		rt.BroadcastStream.SetTxEnabled(false)
+		bs.SetTxEnabled(false)
 	}
 
 	cfg.drainPlaybackBuffer(rt)

--- a/internal/comms/transmit_test.go
+++ b/internal/comms/transmit_test.go
@@ -26,13 +26,15 @@ func newTestRuntime(stream BroadcastCapture) *CommsRuntime {
 	pc.ReceiveEnabled.Store(true)
 	pc.PlaybackBuffer = make(chan []int16, 16)
 
-	return &CommsRuntime{
+	rt := &CommsRuntime{
 		Ports:           []*PortChannel{pc},
 		BeepBufferStart: []int16{100, 200},
 		BeepBufferStop:  []int16{300, 400},
-		BroadcastStream: stream,
 		Decoder:         &mockDecoder{},
 	}
+	rt.SetBroadcast(stream)
+
+	return rt
 }
 
 func TestBeginTransmission_StartsStream(t *testing.T) {
@@ -652,9 +654,9 @@ func TestEndTransmission_QueuesStopBeepToAllPorts(t *testing.T) {
 		Ports:           []*PortChannel{pc0, pc1},
 		BeepBufferStart: []int16{100, 200},
 		BeepBufferStop:  []int16{300, 400},
-		BroadcastStream: &mockStream{},
 		Decoder:         &mockDecoder{},
 	}
+	rt.SetBroadcast(&mockStream{})
 
 	cfg := newSilentComms()
 

--- a/internal/comms/transmit_test.go
+++ b/internal/comms/transmit_test.go
@@ -2,11 +2,13 @@ package comms
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/openmanet/openmanetd/internal/comms/control"
 	"github.com/openmanet/openmanetd/internal/comms/rtp"
@@ -752,4 +754,188 @@ func TestBeginTransmission_WebMode_HalfDuplexStillWorks(t *testing.T) {
 	if cfg.isBroadcasting(rt) {
 		t.Error("should not be broadcasting while receiving remote audio, even in web mode")
 	}
+}
+
+// ─── In-run audio recovery ──────────────────────────────────────────────────
+
+// countingStartHA is a mutex-protected fake for startHardwareAudioFn that
+// fails failN times, then succeeds. Success installs a mockStream the same
+// way the real startHardwareAudio does and signals succeeded (once).
+type countingStartHA struct {
+	mu        sync.Mutex
+	calls     int
+	failN     int
+	cleanups  int
+	succeeded chan struct{}
+}
+
+func (f *countingStartHA) fn(rt *CommsRuntime) (func(), error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.calls++
+	if f.calls <= f.failN {
+		return nil, errors.New("simulated: miniaudio: Broken pipe")
+	}
+
+	rt.SetBroadcast(&mockStream{})
+
+	select {
+	case <-f.succeeded:
+	default:
+		close(f.succeeded)
+	}
+
+	return func() { f.mu.Lock(); f.cleanups++; f.mu.Unlock() }, nil
+}
+
+func (f *countingStartHA) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.calls
+}
+
+// TestRun_AudioRecovery_RetriesUntilSuccess verifies that when comms starts
+// without hardware audio (e.g. OpenVLM unplugged or dmix EPIPE at boot),
+// the Run loop re-attempts init on the recovery ticker and installs the
+// stream on success, without a daemon restart.
+func TestRun_AudioRecovery_RetriesUntilSuccess(t *testing.T) {
+	fake := &countingStartHA{failN: 2, succeeded: make(chan struct{})}
+
+	cfg := &CommsConfig{
+		Log:                   zerolog.Nop(),
+		ControlSource:         defaultCtrlSrc,
+		audioRecoveryInterval: 5 * time.Millisecond,
+		startHardwareAudioFn:  fake.fn,
+	}
+
+	rt := &CommsRuntime{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		cfg.Run(ctx, rt, &mockEventSource{ch: make(chan control.PTTEvent)})
+		close(done)
+	}()
+
+	select {
+	case <-fake.succeeded:
+	case <-time.After(2 * time.Second):
+		t.Fatal("recovery never succeeded")
+	}
+
+	cancel()
+	<-done
+
+	assert.Equal(t, 3, fake.callCount(), "two failures then one success")
+	assert.NotNil(t, rt.Broadcast(), "recovered stream must be installed")
+	assert.NotNil(t, rt.audioCleanup, "recovery must stash the cleanup for Start's defer")
+}
+
+// TestRun_AudioRecovery_StopsAfterSuccess verifies the ticker is disarmed
+// once audio is up: no further init attempts occur.
+func TestRun_AudioRecovery_StopsAfterSuccess(t *testing.T) {
+	fake := &countingStartHA{failN: 0, succeeded: make(chan struct{})}
+
+	cfg := &CommsConfig{
+		Log:                   zerolog.Nop(),
+		ControlSource:         defaultCtrlSrc,
+		audioRecoveryInterval: time.Millisecond,
+		startHardwareAudioFn:  fake.fn,
+	}
+
+	rt := &CommsRuntime{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		cfg.Run(ctx, rt, &mockEventSource{ch: make(chan control.PTTEvent)})
+		close(done)
+	}()
+
+	<-fake.succeeded
+
+	// Give the ticker room to misfire if the disarm were broken, without
+	// asserting on wall-clock behavior: poll until call count is stable
+	// across two observations 20 ticker-periods apart.
+	deadline := time.After(2 * time.Second)
+
+	for {
+		before := fake.callCount()
+
+		select {
+		case <-deadline:
+			t.Fatal("call count never stabilized")
+		case <-time.After(20 * time.Millisecond):
+		}
+
+		if fake.callCount() == before {
+			break
+		}
+	}
+
+	cancel()
+	<-done
+
+	assert.Equal(t, 1, fake.callCount(), "no attempts after success")
+}
+
+// TestRun_AudioRecovery_DisabledWhenHealthy verifies no recovery attempts
+// happen when startup already produced a stream.
+func TestRun_AudioRecovery_DisabledWhenHealthy(t *testing.T) {
+	cfg := &CommsConfig{
+		Log:                   zerolog.Nop(),
+		ControlSource:         defaultCtrlSrc,
+		audioRecoveryInterval: time.Millisecond,
+		startHardwareAudioFn: func(_ *CommsRuntime) (func(), error) {
+			t.Error("recovery must not run when audio is already up")
+
+			return nil, nil
+		},
+	}
+
+	rt := &CommsRuntime{}
+	rt.SetBroadcast(&mockStream{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		cfg.Run(ctx, rt, &mockEventSource{ch: make(chan control.PTTEvent)})
+		close(done)
+	}()
+
+	time.AfterFunc(50*time.Millisecond, cancel)
+	<-done
+}
+
+// TestRun_AudioRecovery_DisabledInWebMode verifies web mode never attempts
+// hardware recovery — the browser owns audio I/O.
+func TestRun_AudioRecovery_DisabledInWebMode(t *testing.T) {
+	cfg := &CommsConfig{
+		Log:                   zerolog.Nop(),
+		ControlSource:         controlSourceWeb,
+		audioRecoveryInterval: time.Millisecond,
+		startHardwareAudioFn: func(_ *CommsRuntime) (func(), error) {
+			t.Error("recovery must not run in web mode")
+
+			return nil, nil
+		},
+	}
+
+	rt := &CommsRuntime{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		cfg.Run(ctx, rt, &mockEventSource{ch: make(chan control.PTTEvent)})
+		close(done)
+	}()
+
+	time.AfterFunc(50*time.Millisecond, cancel)
+	<-done
 }

--- a/internal/comms/transmit_test.go
+++ b/internal/comms/transmit_test.go
@@ -801,6 +801,12 @@ func (f *countingStartHA) callCount() int {
 // the Run loop re-attempts init on the recovery ticker and installs the
 // stream on success, without a daemon restart.
 func TestRun_AudioRecovery_RetriesUntilSuccess(t *testing.T) {
+	// Gate off real ALSA card detection: ControlSource is defaultCtrlSrc,
+	// which would otherwise make tryAudioRecovery walk /sys and
+	// /proc/asound and potentially os.Setenv("ALSA_CARD", ...) for real on
+	// a dev machine with a CM108-class device attached.
+	t.Setenv("ALSA_CARD", "0")
+
 	fake := &countingStartHA{failN: 2, succeeded: make(chan struct{})}
 
 	cfg := &CommsConfig{
@@ -837,6 +843,9 @@ func TestRun_AudioRecovery_RetriesUntilSuccess(t *testing.T) {
 // TestRun_AudioRecovery_StopsAfterSuccess verifies the ticker is disarmed
 // once audio is up: no further init attempts occur.
 func TestRun_AudioRecovery_StopsAfterSuccess(t *testing.T) {
+	// Gate off real ALSA card detection — see RetriesUntilSuccess above.
+	t.Setenv("ALSA_CARD", "0")
+
 	fake := &countingStartHA{failN: 0, succeeded: make(chan struct{})}
 
 	cfg := &CommsConfig{
@@ -938,4 +947,49 @@ func TestRun_AudioRecovery_DisabledInWebMode(t *testing.T) {
 
 	time.AfterFunc(50*time.Millisecond, cancel)
 	<-done
+}
+
+// TestTryAudioRecovery_DetectionGate verifies tryAudioRecovery invokes the
+// ALSA card detection seam only when ALSA_CARD is unset, and never when a
+// card is already pinned (detected at startup or set manually) — the gate
+// that keeps recovery from re-walking /sys and /proc/asound once a card is
+// known.
+func TestTryAudioRecovery_DetectionGate(t *testing.T) {
+	tests := []struct {
+		name       string
+		alsaCard   string
+		wantDetect bool
+	}{
+		{name: "unset triggers detection", alsaCard: "", wantDetect: true},
+		{name: "set skips detection", alsaCard: "2", wantDetect: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ALSA_CARD", tc.alsaCard)
+
+			detectCalls := 0
+			cfg := &CommsConfig{
+				Log:           zerolog.Nop(),
+				ControlSource: defaultCtrlSrc,
+				detectALSACardFn: func() {
+					detectCalls++
+				},
+				startHardwareAudioFn: func(_ *CommsRuntime) (func(), error) {
+					return nil, errors.New("simulated: no card available")
+				},
+			}
+
+			rt := &CommsRuntime{}
+
+			cfg.tryAudioRecovery(rt, 1)
+
+			wantCalls := 0
+			if tc.wantDetect {
+				wantCalls = 1
+			}
+
+			assert.Equal(t, wantCalls, detectCalls, "detection seam call count")
+		})
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,8 +31,8 @@ func TestGetMeshNetInterface(t *testing.T) {
 	}{
 		{
 			name:     "returns configured value",
-			setValue: strPtr("wlan0"),
-			want:     "wlan0",
+			setValue: strPtr("wlh0"),
+			want:     "wlh0",
 		},
 		{
 			name:     "returns default when empty",
@@ -1081,14 +1081,14 @@ func TestConfigReload(t *testing.T) {
 	}
 
 	// Change configuration values
-	v.Set("meshNetInterface", "wlan0")
+	v.Set("meshNetInterface", "wlh0")
 
 	// Manually trigger reload (simulating config file change)
 	cfg.reload()
 
 	// Check updated values
-	if got := cfg.GetMeshNetInterface(); got != "wlan0" {
-		t.Errorf("After reload GetMeshNetInterface() = %v, want wlan0", got)
+	if got := cfg.GetMeshNetInterface(); got != "wlh0" {
+		t.Errorf("After reload GetMeshNetInterface() = %v, want wlh0", got)
 	}
 }
 
@@ -1108,7 +1108,7 @@ func TestConfigOnChangeCallback(t *testing.T) {
 	})
 
 	// Change config and trigger reload
-	v.Set("meshNetInterface", "wlan0")
+	v.Set("meshNetInterface", "wlh0")
 	cfg.reload()
 	cfg.notifyCallbacks()
 
@@ -1120,8 +1120,8 @@ func TestConfigOnChangeCallback(t *testing.T) {
 		t.Error("Callback did not receive the correct Config instance")
 	}
 
-	if got := receivedConfig.GetMeshNetInterface(); got != "wlan0" {
-		t.Errorf("Callback config GetMeshNetInterface() = %v, want wlan0", got)
+	if got := receivedConfig.GetMeshNetInterface(); got != "wlh0" {
+		t.Errorf("Callback config GetMeshNetInterface() = %v, want wlh0", got)
 	}
 }
 

--- a/internal/frontend/handlers.go
+++ b/internal/frontend/handlers.go
@@ -485,8 +485,12 @@ func (s *Server) handleNetworkWifi(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fallback: enumerate wlan interfaces.
-	matches, _ := filepath.Glob("/sys/class/net/wlan*")
+	// Fallback: enumerate wireless interfaces (wlan*, wlh*).
+	wlanMatches, _ := filepath.Glob("/sys/class/net/wlan*")
+	wlhMatches, _ := filepath.Glob("/sys/class/net/wlh*")
+	matches := make([]string, 0, len(wlanMatches)+len(wlhMatches))
+	matches = append(matches, wlanMatches...)
+	matches = append(matches, wlhMatches...)
 	statuses := make([]wifiStatus, 0, len(matches))
 
 	for _, m := range matches {

--- a/internal/iwinfo/iwinfo_test.go
+++ b/internal/iwinfo/iwinfo_test.go
@@ -74,7 +74,7 @@ func TestGetDevicesWithExecutor_Success(t *testing.T) {
 	devices, err := iwinfo.GetDevicesWithExecutor(context.Background(), mock)
 
 	require.NoError(t, err)
-	assert.Equal(t, []string{"phy1-mesh0", "wlan-10-04", "wlan0"}, devices)
+	assert.Equal(t, []string{"phy1-mesh0", "wlh-10-04", "wlh0"}, devices)
 }
 
 func TestGetDevicesWithExecutor_EmptyList(t *testing.T) {
@@ -165,7 +165,7 @@ func TestGetInfoWithExecutor_MediaTek(t *testing.T) {
 func TestGetInfoWithExecutor_Cypress_AllUnknownFields(t *testing.T) {
 	mock := &mockUbusExecutor{output: readFixture(t, "info_cypress.json")}
 
-	info, err := iwinfo.GetInfoWithExecutor(context.Background(), mock, "wlan-10-04")
+	info, err := iwinfo.GetInfoWithExecutor(context.Background(), mock, "wlh-10-04")
 
 	require.NoError(t, err)
 	require.NotNil(t, info)
@@ -195,7 +195,7 @@ func TestGetInfoWithExecutor_Cypress_AllUnknownFields(t *testing.T) {
 func TestGetInfoWithExecutor_MorseMicro_HaLow(t *testing.T) {
 	mock := &mockUbusExecutor{output: readFixture(t, "info_morsemicro.json")}
 
-	info, err := iwinfo.GetInfoWithExecutor(context.Background(), mock, "wlan0")
+	info, err := iwinfo.GetInfoWithExecutor(context.Background(), mock, "wlh0")
 
 	require.NoError(t, err)
 	require.NotNil(t, info)
@@ -228,7 +228,7 @@ func TestGetInfoWithExecutor_MorseMicro_HaLow(t *testing.T) {
 func TestGetInfoWithExecutor_UbusError(t *testing.T) {
 	mock := &mockUbusExecutor{err: errors.New("no such device")}
 
-	_, err := iwinfo.GetInfoWithExecutor(context.Background(), mock, "wlan0")
+	_, err := iwinfo.GetInfoWithExecutor(context.Background(), mock, "wlh0")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no such device")
@@ -237,7 +237,7 @@ func TestGetInfoWithExecutor_UbusError(t *testing.T) {
 func TestGetInfoWithExecutor_MalformedJSON(t *testing.T) {
 	mock := &mockUbusExecutor{output: []byte(`{bad json`)}
 
-	_, err := iwinfo.GetInfoWithExecutor(context.Background(), mock, "wlan0")
+	_, err := iwinfo.GetInfoWithExecutor(context.Background(), mock, "wlh0")
 
 	require.Error(t, err)
 }
@@ -246,7 +246,7 @@ func TestGetInfoWithExecutor_EmptyObject(t *testing.T) {
 	// Empty JSON object: all struct fields take zero values — must not panic.
 	mock := &mockUbusExecutor{output: []byte(`{}`)}
 
-	info, err := iwinfo.GetInfoWithExecutor(context.Background(), mock, "wlan0")
+	info, err := iwinfo.GetInfoWithExecutor(context.Background(), mock, "wlh0")
 
 	require.NoError(t, err)
 	require.NotNil(t, info)
@@ -262,8 +262,8 @@ func TestGetInfoForAllWithExecutor_AllThreeDevices(t *testing.T) {
 		responses: map[string]mockResponse{
 			"devices":                 {output: readFixture(t, "devices.json")},
 			`{"device":"phy1-mesh0"}`: {output: readFixture(t, "info_mediatek.json")},
-			`{"device":"wlan-10-04"}`: {output: readFixture(t, "info_cypress.json")},
-			`{"device":"wlan0"}`:      {output: readFixture(t, "info_morsemicro.json")},
+			`{"device":"wlh-10-04"}`:  {output: readFixture(t, "info_cypress.json")},
+			`{"device":"wlh0"}`:       {output: readFixture(t, "info_morsemicro.json")},
 		},
 	}
 
@@ -272,8 +272,8 @@ func TestGetInfoForAllWithExecutor_AllThreeDevices(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result, 3)
 	assert.Equal(t, "MediaTek MT7916AN", result["phy1-mesh0"].Hardware.Name)
-	assert.Equal(t, "Cypress CYW43455", result["wlan-10-04"].Hardware.Name)
-	assert.Equal(t, "Morse Micro SPI-MM601X", result["wlan0"].Hardware.Name)
+	assert.Equal(t, "Cypress CYW43455", result["wlh-10-04"].Hardware.Name)
+	assert.Equal(t, "Morse Micro SPI-MM601X", result["wlh0"].Hardware.Name)
 }
 
 func TestGetInfoForAllWithExecutor_EmptyDeviceList(t *testing.T) {
@@ -300,8 +300,8 @@ func TestGetInfoForAllWithExecutor_OneDeviceFails(t *testing.T) {
 		responses: map[string]mockResponse{
 			"devices":                 {output: readFixture(t, "devices.json")},
 			`{"device":"phy1-mesh0"}`: {output: readFixture(t, "info_mediatek.json")},
-			`{"device":"wlan-10-04"}`: {err: errors.New("interface down")},
-			`{"device":"wlan0"}`:      {err: errors.New("interface down")},
+			`{"device":"wlh-10-04"}`:  {err: errors.New("interface down")},
+			`{"device":"wlh0"}`:       {err: errors.New("interface down")},
 		},
 	}
 
@@ -310,8 +310,8 @@ func TestGetInfoForAllWithExecutor_OneDeviceFails(t *testing.T) {
 	// Partial failure: error is reported but successful devices are still returned.
 	require.Error(t, err)
 	assert.Contains(t, result, "phy1-mesh0")
-	assert.NotContains(t, result, "wlan-10-04")
-	assert.NotContains(t, result, "wlan0")
+	assert.NotContains(t, result, "wlh-10-04")
+	assert.NotContains(t, result, "wlh0")
 	assert.Equal(t, "MediaTek MT7916AN", result["phy1-mesh0"].Hardware.Name)
 }
 
@@ -470,11 +470,11 @@ func TestUbusArgs_GetInfo(t *testing.T) {
 		fallback: mockResponse{output: []byte(`{}`)},
 	}
 
-	_, err := iwinfo.GetInfoWithExecutor(context.Background(), exec, "wlan0")
+	_, err := iwinfo.GetInfoWithExecutor(context.Background(), exec, "wlh0")
 
 	require.NoError(t, err)
 	require.Len(t, exec.calls, 1)
-	assert.Equal(t, []string{"call", "iwinfo", "info", `{"device":"wlan0"}`}, exec.calls[0])
+	assert.Equal(t, []string{"call", "iwinfo", "info", `{"device":"wlh0"}`}, exec.calls[0])
 }
 
 func TestUbusArgs_GetInfo_HyphenatedName(t *testing.T) {
@@ -492,8 +492,8 @@ func TestUbusArgs_GetInfo_HyphenatedName(t *testing.T) {
 func TestUbusArgs_GetInfoForAll_CallSequence(t *testing.T) {
 	exec := &dispatchUbusExecutor{
 		responses: map[string]mockResponse{
-			"devices":            {output: []byte(`{"devices":["wlan0"]}`)},
-			`{"device":"wlan0"}`: {output: readFixture(t, "info_morsemicro.json")},
+			"devices":           {output: []byte(`{"devices":["wlh0"]}`)},
+			`{"device":"wlh0"}`: {output: readFixture(t, "info_morsemicro.json")},
 		},
 	}
 
@@ -503,7 +503,7 @@ func TestUbusArgs_GetInfoForAll_CallSequence(t *testing.T) {
 	// First call: devices list; second call: per-device info.
 	require.Len(t, exec.calls, 2)
 	assert.Equal(t, []string{"call", "iwinfo", "devices"}, exec.calls[0])
-	assert.Equal(t, []string{"call", "iwinfo", "info", `{"device":"wlan0"}`}, exec.calls[1])
+	assert.Equal(t, []string{"call", "iwinfo", "info", `{"device":"wlh0"}`}, exec.calls[1])
 }
 
 // ── Client ────────────────────────────────────────────────────────────────────
@@ -538,8 +538,8 @@ func TestClient_GetInfoForAll(t *testing.T) {
 		responses: map[string]mockResponse{
 			"devices":                 {output: readFixture(t, "devices.json")},
 			`{"device":"phy1-mesh0"}`: {output: readFixture(t, "info_mediatek.json")},
-			`{"device":"wlan-10-04"}`: {output: readFixture(t, "info_cypress.json")},
-			`{"device":"wlan0"}`:      {output: readFixture(t, "info_morsemicro.json")},
+			`{"device":"wlh-10-04"}`:  {output: readFixture(t, "info_cypress.json")},
+			`{"device":"wlh0"}`:       {output: readFixture(t, "info_morsemicro.json")},
 		},
 	}
 	client := iwinfo.NewClientWithExecutor(exec)

--- a/internal/mgmt/device_test.go
+++ b/internal/mgmt/device_test.go
@@ -429,9 +429,9 @@ func TestSetupBatMesh1Interface_HardwareMatch_MT7915(t *testing.T) {
 	wireless := newFakeWirelessReader()
 	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
 	// No mesh iface seeded — expect it to fail past the hardware check.
-	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
+	iw := makeIwinfoWithHardware("wlh0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlh0"))
 	// Should fail at "no mesh iface", not at "no supported hardware".
 	if err == nil {
 		t.Fatal("expected error after hardware check (no mesh iface)")
@@ -450,9 +450,9 @@ func TestSetupBatMesh1Interface_HardwareMatch_MT7916(t *testing.T) {
 	wireless := newFakeWirelessReader()
 	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
 
-	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7916AN")
+	iw := makeIwinfoWithHardware("wlh0", "MediaTek MT7916AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlh0"))
 	// Should fail at "no mesh iface", not at "no supported hardware".
 	if err == nil {
 		t.Fatal("expected error after hardware check (no mesh iface)")
@@ -474,9 +474,9 @@ func TestSetupBatMesh1Interface_NoMeshIface(t *testing.T) {
 	_ = wireless.SetType("wireless", "default_radio0", "mode", uci.TypeOption, "ap")
 	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
 
-	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
+	iw := makeIwinfoWithHardware("wlh0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlh0"))
 	if err == nil {
 		t.Fatal("expected error when no mesh iface found")
 	}
@@ -498,9 +498,9 @@ func TestSetupBatMesh1Interface_IfaceSectionsError(t *testing.T) {
 		sectionType:  "wifi-iface",
 		err:          errors.New("read interfaces"),
 	}
-	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
+	iw := makeIwinfoWithHardware("wlh0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, reader, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, reader, iw, wirelessStatusForRadio(t, "radio1", "wlh0"))
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "get wifi-iface sections")
 }
@@ -515,9 +515,9 @@ func TestSetupBatMesh1Interface_No2gDevice(t *testing.T) {
 	// Only a non-2g device.
 	wireless.seedWifiDevice("radio4", "s1g", "42", "")
 
-	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
+	iw := makeIwinfoWithHardware("wlh0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio4", "wlan0"))
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio4", "wlh0"))
 	if err != nil {
 		t.Fatalf("expected safe no-op when no supported 2.4 GHz radio exists, got %v", err)
 	}
@@ -536,9 +536,9 @@ func TestSetupBatMesh1Interface_Success(t *testing.T) {
 	wireless.seedMeshIface("existing_mesh0", "radio4", "halowmesh", "secretkey999")
 	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
 
-	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
+	iw := makeIwinfoWithHardware("wlh0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlh0"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -675,9 +675,9 @@ func TestSetupBatMesh1Interface_SetIfaceError(t *testing.T) {
 	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
 	wireless.setTypeErr = errors.New("UCI write failure")
 
-	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
+	iw := makeIwinfoWithHardware("wlh0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlh0"))
 	if err == nil {
 		t.Fatal("expected error when SetWirelessIface fails")
 	}
@@ -700,9 +700,9 @@ func TestSetupBatMesh1Interface_SetDeviceError(t *testing.T) {
 	// device update commit fails.
 	wireless.commitErr = errors.New("commit failure")
 
-	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
+	iw := makeIwinfoWithHardware("wlh0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlh0"))
 	if err == nil {
 		t.Fatal("expected error when Commit fails")
 	}
@@ -723,9 +723,9 @@ func TestSetupBatMesh1Interface_SetConfiguredError(t *testing.T) {
 	wireless.seedMeshIface("existing_mesh0", "radio4", "halowmesh", "secretkey")
 	wireless.seedWifiDevice("radio1", "2g", "6", "HT20")
 
-	iw := makeIwinfoWithHardware("wlan0", "MediaTek MT7915AN")
+	iw := makeIwinfoWithHardware("wlh0", "MediaTek MT7915AN")
 
-	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlan0"))
+	err := m.setupBatMesh1InterfaceWithDeps(context.Background(), openmanet, wireless, iw, wirelessStatusForRadio(t, "radio1", "wlh0"))
 	if err == nil {
 		t.Fatal("expected error when openmanet Commit fails")
 	}

--- a/internal/mgmt/mesh_neighbors.go
+++ b/internal/mgmt/mesh_neighbors.go
@@ -21,8 +21,8 @@ import (
 // ifaceSuffixRe matches a trailing "_<iface>" token whose first
 // character is a lowercase letter — the structural fingerprint of
 // every Linux network interface name OpenMANET nodes carry on the
-// wire (bat0, wlan0, eth0, vxlan0, phy2-mesh0, br-ahwlan,
-// wlan-10-04, mesh0, etc.). The character class allows letters,
+// wire (bat0, wlh0, eth0, vxlan0, phy2-mesh0, br-ahwlan,
+// wlh-10-04, mesh0, etc.). The character class allows letters,
 // digits, dashes, AND underscores so a hostname carrying a chain of
 // suffixes ("BCM2711-88ba_phy2-mesh0_bat0") is consumed in a single
 // match. Anything starting with a digit ("_27") or uppercase letter
@@ -256,7 +256,7 @@ func mapOriginatorsBestOnly(getOrigs func() ([]batmanadv.Originator, error), log
 // stripIfaceSuffix removes a trailing "_<iface>" token from a bat-hosts
 // hostname, e.g. "BCM2711-97d6_bat0" → "BCM2711-97d6". Only strips
 // suffixes that match a recognized network interface name (bat0,
-// vxlan0, wlan0, eth0, etc.) so legitimate underscored hostnames like
+// vxlan0, wlh0, eth0, etc.) so legitimate underscored hostnames like
 // "Gate_04_27" are preserved verbatim. Duplicated from the
 // mesh_topology handler — keep the two in lockstep.
 func stripIfaceSuffix(name string) string {
@@ -270,7 +270,7 @@ func stripIfaceSuffix(name string) string {
 
 // listLocalInterfaceMacs returns the lowercased MACs of local layer-2
 // interfaces that participate (or could participate) in batman-adv
-// routing — bat0, vxlan0, wlan0, phy<N>-mesh<N>, eth*, etc. Filters
+// routing — bat0, vxlan0, wlh0, phy<N>-mesh<N>, eth*, etc. Filters
 // applied:
 //
 //   - skip loopback (no MAC anyway, but explicit)

--- a/internal/mgmt/mesh_neighbors_test.go
+++ b/internal/mgmt/mesh_neighbors_test.go
@@ -21,15 +21,15 @@ func TestMeshNeighborsWorker_SendOncePublishesExpectedPayload(t *testing.T) {
 	fixedTime := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
 
 	neighbors := batmanadv.Neighbors{
-		{HardIfname: "wlan0", NeighAddress: "AA:AA:AA:AA:AA:01", LastSeenMsecs: 200, Throughput: 54000},
+		{HardIfname: "wlh0", NeighAddress: "AA:AA:AA:AA:AA:01", LastSeenMsecs: 200, Throughput: 54000},
 		{HardIfname: "vxlan0", NeighAddress: "bb:bb:bb:bb:bb:01", LastSeenMsecs: 400, Throughput: 100000},
 		{HardIfname: "eth0", NeighAddress: "Cc:Cc:Cc:Cc:Cc:01", LastSeenMsecs: 50, Throughput: 1000000},
 	}
 
 	originators := []batmanadv.Originator{
-		{OrigAddress: "aa:aa:aa:aa:aa:01", BestNeigh: "aa:aa:aa:aa:aa:01", HardIfname: "wlan0", Throughput: 54000, TQ: 220, Best: true},
+		{OrigAddress: "aa:aa:aa:aa:aa:01", BestNeigh: "aa:aa:aa:aa:aa:01", HardIfname: "wlh0", Throughput: 54000, TQ: 220, Best: true},
 		// Non-best row — must be filtered out.
-		{OrigAddress: "aa:aa:aa:aa:aa:01", BestNeigh: "dd:dd:dd:dd:dd:01", HardIfname: "wlan0", Throughput: 20000, TQ: 120, Best: false},
+		{OrigAddress: "aa:aa:aa:aa:aa:01", BestNeigh: "dd:dd:dd:dd:dd:01", HardIfname: "wlh0", Throughput: 20000, TQ: 120, Best: false},
 		{OrigAddress: "bb:bb:bb:bb:bb:01", BestNeigh: "bb:bb:bb:bb:bb:01", HardIfname: "vxlan0", Throughput: 100000, TQ: 0, Best: true},
 	}
 
@@ -81,8 +81,8 @@ func TestMeshNeighborsWorker_SendOncePublishesExpectedPayload(t *testing.T) {
 
 	wlan, ok := byMac["aa:aa:aa:aa:aa:01"]
 	require.True(t, ok)
-	assert.Equal(t, "wlan0", wlan.GetHardIfname())
-	assert.False(t, wlan.GetBlos(), "wlan0 is not BLOS")
+	assert.Equal(t, "wlh0", wlan.GetHardIfname())
+	assert.False(t, wlan.GetBlos(), "wlh0 is not BLOS")
 	assert.Equal(t, int32(200), wlan.GetLastSeenMsecs())
 	assert.Equal(t, int64(54000), wlan.GetThroughputKbps())
 
@@ -104,7 +104,7 @@ func TestMeshNeighborsWorker_SendOncePublishesExpectedPayload(t *testing.T) {
 
 	require.Contains(t, origByMac, "aa:aa:aa:aa:aa:01")
 	assert.Equal(t, int32(220), origByMac["aa:aa:aa:aa:aa:01"].GetTq())
-	assert.Equal(t, "wlan0", origByMac["aa:aa:aa:aa:aa:01"].GetHardIfname())
+	assert.Equal(t, "wlh0", origByMac["aa:aa:aa:aa:aa:01"].GetHardIfname())
 
 	// InterfaceMacs include the bat0 primary plus every MAC the
 	// listMacs hook returned, deduped and lowercased. Receivers index
@@ -125,12 +125,12 @@ func TestStripIfaceSuffix(t *testing.T) {
 	}{
 		// Canonical iface suffixes from the production bat-hosts.
 		{"BCM2711-97d6_bat0", "BCM2711-97d6"},
-		{"BCM2711-97d6_wlan0", "BCM2711-97d6"},
+		{"BCM2711-97d6_wlh0", "BCM2711-97d6"},
 		{"BCM2711-97d6_phy2-mesh0", "BCM2711-97d6"},
 		{"BCM2711-97d6_eth0", "BCM2711-97d6"},
-		{"BCM2711-97d6_wlan-97-d9", "BCM2711-97d6"},
+		{"BCM2711-97d6_wlh-97-d9", "BCM2711-97d6"},
 		{"BCM2711-88ba_br-ahwlan", "BCM2711-88ba"},
-		{"BCM2711-1003_wlan-10-04", "BCM2711-1003"},
+		{"BCM2711-1003_wlh-10-04", "BCM2711-1003"},
 		{"BCM2711-1003_phy1-mesh0", "BCM2711-1003"},
 		{"HaLow-R-b65c57_phy0-mesh0", "HaLow-R-b65c57"},
 		{"HaLow-R-b65c57_mesh0", "HaLow-R-b65c57"},
@@ -201,7 +201,7 @@ func TestIsNonMeshInterfaceName(t *testing.T) {
 		// Mesh-relevant interfaces must NOT be filtered.
 		{"bat0", false},
 		{"vxlan0", false},
-		{"wlan0", false},
+		{"wlh0", false},
 		{"phy2-mesh0", false},
 		{"eth0", false},
 		{"br-ahwlan", false},
@@ -244,7 +244,7 @@ func TestCollectInterfaceMacs(t *testing.T) {
 // fails — neighbor data is useful on its own.
 func TestMeshNeighborsWorker_OriginatorFailureStillPublishesNeighbors(t *testing.T) {
 	neighbors := batmanadv.Neighbors{
-		{HardIfname: "wlan0", NeighAddress: "aa:aa:aa:aa:aa:01", LastSeenMsecs: 100, Throughput: 30000},
+		{HardIfname: "wlh0", NeighAddress: "aa:aa:aa:aa:aa:01", LastSeenMsecs: 100, Throughput: 30000},
 	}
 
 	fake := &fakeAlfredClient{}

--- a/internal/mgmt/wireless_test.go
+++ b/internal/mgmt/wireless_test.go
@@ -72,7 +72,7 @@ func TestGetMeshInterfaces_FiltersCorrectly(t *testing.T) {
 
 func TestGetMeshInterfaces_ReturnsMeshPointType(t *testing.T) {
 	ifaces := []*wifi.Interface{
-		{Type: wifi.InterfaceTypeStation, Name: "wlan0"},
+		{Type: wifi.InterfaceTypeStation, Name: "wlh0"},
 		{Type: wifi.InterfaceTypeMeshPoint, Name: "mesh0"},
 		{Type: wifi.InterfaceTypeAP, Name: "ap0"},
 		{Type: wifi.InterfaceTypeMeshPoint, Name: "mesh1"},

--- a/internal/network/interface_info.go
+++ b/internal/network/interface_info.go
@@ -16,7 +16,7 @@ const (
 	LinkTypeUnknown   InterfaceLinkType = iota
 	LinkTypeBridge                      // br-ahwlan, br-lan, etc.
 	LinkTypeEthernet                    // eth0, eth1, etc.
-	LinkTypeWiFiAP                      // wlan0 in AP mode
+	LinkTypeWiFiAP                      // wlh0 in AP mode
 	LinkTypeHaLowMesh                   // phy1-ap0 (HaLow mesh)
 	LinkTypeBatman                      // bat0 (batman-adv)
 	LinkTypeLoopback                    // lo

--- a/internal/network/interface_info_test.go
+++ b/internal/network/interface_info_test.go
@@ -71,9 +71,9 @@ func TestClassifyLink_NameHeuristics(t *testing.T) {
 
 func TestClassifyLink_WifiTypes(t *testing.T) {
 	wifiTypes := map[string]wifi.InterfaceType{
-		"wlan0":      wifi.InterfaceTypeMeshPoint,
+		"wlh0":       wifi.InterfaceTypeMeshPoint,
 		"phy0-mesh0": wifi.InterfaceTypeMeshPoint,
-		"wlan1":      wifi.InterfaceTypeAP,
+		"wlh1":       wifi.InterfaceTypeAP,
 	}
 
 	tests := []struct {
@@ -81,10 +81,10 @@ func TestClassifyLink_WifiTypes(t *testing.T) {
 		linkName string
 		want     InterfaceLinkType
 	}{
-		{"mesh point wlan0", "wlan0", LinkTypeHaLowMesh},
+		{"mesh point wlh0", "wlh0", LinkTypeHaLowMesh},
 		{"mesh point phy0-mesh0", "phy0-mesh0", LinkTypeHaLowMesh},
-		{"ap wlan1", "wlan1", LinkTypeWiFiAP},
-		{"unknown wifi not in map", "wlan9", LinkTypeUnknown},
+		{"ap wlh1", "wlh1", LinkTypeWiFiAP},
+		{"unknown wifi not in map", "wlh9", LinkTypeUnknown},
 	}
 
 	for _, tt := range tests {

--- a/internal/network/route.go
+++ b/internal/network/route.go
@@ -21,7 +21,7 @@ var (
 // Fields:
 //   - Destination: The destination network in CIDR notation. nil represents a default route.
 //   - Gateway: The gateway IP address for the route. nil for directly connected networks.
-//   - Interface: The name of the network interface to use for this route (e.g., "eth0", "wlan0").
+//   - Interface: The name of the network interface to use for this route (e.g., "eth0", "wlh0").
 //   - Metric: The route priority/metric. Lower values have higher priority.
 //   - Table: The routing table ID (e.g., unix.RT_TABLE_MAIN for the main table).
 //   - Scope: The scope of the route (e.g., netlink.SCOPE_UNIVERSE for global routes).

--- a/internal/network/route_test.go
+++ b/internal/network/route_test.go
@@ -73,11 +73,11 @@ func TestRoute_String(t *testing.T) {
 			route: &Route{
 				Destination: createTestIPNet("10.0.0.0/8"),
 				Gateway:     net.ParseIP("192.168.1.1"),
-				Interface:   "wlan0",
+				Interface:   "wlh0",
 				Metric:      50,
 				Table:       255,
 			},
-			want: "10.0.0.0/8 via 192.168.1.1 dev wlan0 metric 50 table 255",
+			want: "10.0.0.0/8 via 192.168.1.1 dev wlh0 metric 50 table 255",
 		},
 		{
 			name: "route without gateway",

--- a/internal/network/uci_network_test.go
+++ b/internal/network/uci_network_test.go
@@ -2445,7 +2445,7 @@ func TestRemovePort(t *testing.T) {
 		{
 			name:          "remove non-existent port",
 			initialPorts:  []string{"eth0", "eth1", "bat0"},
-			portToRemove:  "wlan0",
+			portToRemove:  "wlh0",
 			expectedPorts: []string{"eth0", "eth1", "bat0"},
 			expectedFound: false,
 		},

--- a/internal/openmanet/server/handlers/cached_interfaces_test.go
+++ b/internal/openmanet/server/handlers/cached_interfaces_test.go
@@ -32,7 +32,7 @@ func (f *fakeCachedInterfaceInner) ListAll() ([]network.NetworkInterfaceInfo, er
 
 func TestCachedInterfaceProvider_ServesFromCacheWithinTTL(t *testing.T) {
 	inner := &fakeCachedInterfaceInner{
-		infos: []network.NetworkInterfaceInfo{{Name: "eth0"}, {Name: "wlan0"}},
+		infos: []network.NetworkInterfaceInfo{{Name: "eth0"}, {Name: "wlh0"}},
 	}
 	p := handlers.NewCachedInterfaceProvider(inner, 500*time.Millisecond)
 

--- a/internal/openmanet/server/handlers/cached_wireless_test.go
+++ b/internal/openmanet/server/handlers/cached_wireless_test.go
@@ -70,13 +70,13 @@ func (f *fakeWirelessInner) StationInfo(iface *wifi.Interface) ([]*wifi.StationI
 
 func TestCachedWirelessProvider_ServesFromCacheWithinTTL(t *testing.T) {
 	meshIface := &wifi.Interface{Name: "phy0-mesh0", Type: wifi.InterfaceTypeMeshPoint}
-	apIface := &wifi.Interface{Name: "wlan0", Type: wifi.InterfaceTypeAP}
+	apIface := &wifi.Interface{Name: "wlh0", Type: wifi.InterfaceTypeAP}
 
 	inner := &fakeWirelessInner{
 		ifaces: []*wifi.Interface{meshIface, apIface},
 		stationsBy: map[string][]*wifi.StationInfo{
 			"phy0-mesh0": {{}, {}},
-			"wlan0":      {{}, {}, {}},
+			"wlh0":       {{}, {}, {}},
 		},
 	}
 
@@ -108,8 +108,8 @@ func TestCachedWirelessProvider_ServesFromCacheWithinTTL(t *testing.T) {
 
 func TestCachedWirelessProvider_RefetchesAfterTTL(t *testing.T) {
 	inner := &fakeWirelessInner{
-		ifaces:     []*wifi.Interface{{Name: "wlan0"}},
-		stationsBy: map[string][]*wifi.StationInfo{"wlan0": {}},
+		ifaces:     []*wifi.Interface{{Name: "wlh0"}},
+		stationsBy: map[string][]*wifi.StationInfo{"wlh0": {}},
 	}
 
 	p := handlers.NewCachedWirelessProvider(inner, 20*time.Millisecond)
@@ -127,12 +127,12 @@ func TestCachedWirelessProvider_RefetchesAfterTTL(t *testing.T) {
 }
 
 func TestCachedWirelessProvider_StationInfoFallsThroughForUnknownIface(t *testing.T) {
-	known := &wifi.Interface{Name: "wlan0"}
+	known := &wifi.Interface{Name: "wlh0"}
 	unknown := &wifi.Interface{Name: "wlan-new"}
 
 	inner := &fakeWirelessInner{
 		ifaces:     []*wifi.Interface{known},
-		stationsBy: map[string][]*wifi.StationInfo{"wlan0": {{}}, "wlan-new": {{}, {}}},
+		stationsBy: map[string][]*wifi.StationInfo{"wlh0": {{}}, "wlan-new": {{}, {}}},
 	}
 
 	p := handlers.NewCachedWirelessProvider(inner, 5*time.Second)
@@ -144,7 +144,7 @@ func TestCachedWirelessProvider_StationInfoFallsThroughForUnknownIface(t *testin
 	// Reset the per-request counter so we can observe the fall-through.
 	inner.stationsCalls.Store(0)
 
-	// wlan0 is in the cache — served without hitting the inner.
+	// wlh0 is in the cache — served without hitting the inner.
 	got, err := p.StationInfo(known)
 	require.NoError(t, err)
 	assert.Len(t, got, 1)
@@ -175,17 +175,17 @@ func TestCachedWirelessProvider_InterfacesErrorIsNotCached(t *testing.T) {
 }
 
 func TestCachedWirelessProvider_PerStationErrorIsCached(t *testing.T) {
-	iface := &wifi.Interface{Name: "wlan0"}
+	iface := &wifi.Interface{Name: "wlh0"}
 	wantErr := errors.New("station dump failed")
 	inner := &fakeWirelessInner{
 		ifaces:      []*wifi.Interface{iface},
-		stationsErr: map[string]error{"wlan0": wantErr},
+		stationsErr: map[string]error{"wlh0": wantErr},
 	}
 
 	p := handlers.NewCachedWirelessProvider(inner, 5*time.Second)
 
 	// First StationInfo triggers refresh; inner is called twice
-	// (Interfaces + StationInfo once for wlan0).
+	// (Interfaces + StationInfo once for wlh0).
 	_, err := p.StationInfo(iface)
 	assert.ErrorIs(t, err, wantErr)
 
@@ -204,8 +204,8 @@ func TestCachedWirelessProvider_PerStationErrorIsCached(t *testing.T) {
 
 func TestCachedWirelessProvider_CoalescesConcurrentRefreshes(t *testing.T) {
 	inner := &fakeWirelessInner{
-		ifaces:     []*wifi.Interface{{Name: "wlan0"}},
-		stationsBy: map[string][]*wifi.StationInfo{"wlan0": {}},
+		ifaces:     []*wifi.Interface{{Name: "wlh0"}},
+		stationsBy: map[string][]*wifi.StationInfo{"wlh0": {}},
 		delay:      50 * time.Millisecond,
 	}
 

--- a/internal/openmanet/server/handlers/mesh_topology.go
+++ b/internal/openmanet/server/handlers/mesh_topology.go
@@ -21,8 +21,8 @@ import (
 // ifaceSuffixRe matches a trailing "_<iface>" token whose first
 // character is a lowercase letter — the structural fingerprint of
 // every Linux network interface name OpenMANET nodes carry on the
-// wire (bat0, wlan0, eth0, vxlan0, phy2-mesh0, br-ahwlan,
-// wlan-10-04, mesh0, etc.). The character class allows letters,
+// wire (bat0, wlh0, eth0, vxlan0, phy2-mesh0, br-ahwlan,
+// wlh-10-04, mesh0, etc.). The character class allows letters,
 // digits, dashes, AND underscores so a hostname carrying a chain of
 // suffixes ("BCM2711-88ba_phy2-mesh0_bat0") is consumed in a single
 // match. Anything starting with a digit ("_27") or uppercase letter

--- a/internal/openmanet/server/handlers/mesh_topology_delta.go
+++ b/internal/openmanet/server/handlers/mesh_topology_delta.go
@@ -288,7 +288,7 @@ func setDiff(curr, prev map[string]struct{}) (added, lost uint32) {
 // only. Non-best rows describe alternative neighbors we aren't forwarding
 // through and would produce spurious "route change" counts on re-election.
 //
-// Including the hard interface means a failover from wlan0 to phy2-mesh0
+// Including the hard interface means a failover from wlh0 to phy2-mesh0
 // (same next hop, new interface) still registers as a route change — which
 // is what operators care about. MAC fields are normalized to lower-case by
 // batmanadv.GetOriginators at ingestion, so set-diff results are stable

--- a/internal/openmanet/server/handlers/mesh_topology_delta_test.go
+++ b/internal/openmanet/server/handlers/mesh_topology_delta_test.go
@@ -105,9 +105,9 @@ func entry(orig, next, iface string) batmanadv.Originator {
 func TestDeltaTracker_WindowRoutesAddedAndLost(t *testing.T) {
 	orig := &fakeOrigScript{
 		snaps: [][]batmanadv.Originator{
-			mkSnap(entry("bb:01", "bb:01", "wlan0")),
-			mkSnap(entry("bb:01", "bb:01", "wlan0"), entry("bb:02", "bb:02", "wlan0")),
-			mkSnap(entry("bb:02", "bb:02", "wlan0")),
+			mkSnap(entry("bb:01", "bb:01", "wlh0")),
+			mkSnap(entry("bb:01", "bb:01", "wlh0"), entry("bb:02", "bb:02", "wlh0")),
+			mkSnap(entry("bb:02", "bb:02", "wlh0")),
 		},
 	}
 	gw := &fakeGateways{sets: []map[string]struct{}{{}, {}, {}}}
@@ -132,13 +132,13 @@ func TestDeltaTracker_WindowRoutesAddedAndLost(t *testing.T) {
 }
 
 // TestDeltaTracker_RouteChangeOnInterfaceFlip verifies that a failover from
-// wlan0 to phy2-mesh0 (same orig, same next hop, different iface) registers
+// wlh0 to phy2-mesh0 (same orig, same next hop, different iface) registers
 // as a route change — this was the whole point of including hardIfname in
 // the edge key.
 func TestDeltaTracker_RouteChangeOnInterfaceFlip(t *testing.T) {
 	orig := &fakeOrigScript{
 		snaps: [][]batmanadv.Originator{
-			mkSnap(entry("bb:01", "bb:01", "wlan0")),
+			mkSnap(entry("bb:01", "bb:01", "wlh0")),
 			mkSnap(entry("bb:01", "bb:01", "phy2-mesh0")),
 		},
 	}
@@ -188,9 +188,9 @@ func TestDeltaTracker_GatewayChanges(t *testing.T) {
 func TestDeltaTracker_ReconvergeZeroWhenStable(t *testing.T) {
 	orig := &fakeOrigScript{
 		snaps: [][]batmanadv.Originator{
-			mkSnap(entry("bb:01", "bb:01", "wlan0")),
-			mkSnap(entry("bb:01", "bb:01", "wlan0")),
-			mkSnap(entry("bb:01", "bb:01", "wlan0")),
+			mkSnap(entry("bb:01", "bb:01", "wlh0")),
+			mkSnap(entry("bb:01", "bb:01", "wlh0")),
+			mkSnap(entry("bb:01", "bb:01", "wlh0")),
 		},
 	}
 	gw := &fakeGateways{sets: []map[string]struct{}{{}, {}, {}}}
@@ -215,9 +215,9 @@ func TestDeltaTracker_ReconvergeZeroWhenStable(t *testing.T) {
 func TestDeltaTracker_ToleratesUnavailable(t *testing.T) {
 	orig := &fakeOrigScript{
 		snaps: [][]batmanadv.Originator{
-			mkSnap(entry("bb:01", "bb:01", "wlan0")),
+			mkSnap(entry("bb:01", "bb:01", "wlh0")),
 			nil,
-			mkSnap(entry("bb:01", "bb:01", "wlan0")),
+			mkSnap(entry("bb:01", "bb:01", "wlh0")),
 		},
 		errs: []error{nil, batmanadv.ErrOriginatorsUnavailable, nil},
 	}

--- a/internal/openmanet/server/handlers/mesh_topology_test.go
+++ b/internal/openmanet/server/handlers/mesh_topology_test.go
@@ -118,9 +118,9 @@ func sampleOrigSnap() *batmanadv.OriginatorTopology {
 		Algorithm:    "BATMAN_V",
 		Originators: []batmanadv.OriginatorEntry{
 			{
-				OrigMAC: "bb:bb:bb:bb:bb:00", OrigHostname: "alpha_wlan0",
-				NextHopMAC: "bb:bb:bb:bb:bb:00", NextHopHostname: "alpha_wlan0",
-				HardIfname: "wlan0", Hops: 1,
+				OrigMAC: "bb:bb:bb:bb:bb:00", OrigHostname: "alpha_wlh0",
+				NextHopMAC: "bb:bb:bb:bb:bb:00", NextHopHostname: "alpha_wlh0",
+				HardIfname: "wlh0", Hops: 1,
 			},
 			{
 				OrigMAC: "cc:cc:cc:cc:cc:00", OrigHostname: "gw1_vxlan0",
@@ -185,7 +185,7 @@ func TestGetMeshTopology_MergesVisAndOriginators(t *testing.T) {
 	assert.False(t, alphaNode.GetIsSelf())
 	assert.Equal(t, "local", alphaNode.GetSegment())
 	assert.Equal(t, int32(1), alphaNode.GetHopsFromSelf())
-	assert.Equal(t, "wlan0", alphaNode.GetMyHardIfname())
+	assert.Equal(t, "wlh0", alphaNode.GetMyHardIfname())
 	assert.Equal(t, "alpha", alphaNode.GetHostname())
 
 	gw1Node := nodes[byMac["cc:cc:cc:cc:cc:00"]]
@@ -599,8 +599,8 @@ func TestGetMeshTopology_SynthesizesEdgesWhenVisEmpty(t *testing.T) {
 	orig := &fakeOrigTopology{snap: &batmanadv.OriginatorTopology{
 		SelfMAC: "aa:aa:aa:aa:aa:00",
 		Originators: []batmanadv.OriginatorEntry{
-			{OrigMAC: "bb:bb:bb:bb:bb:00", NextHopMAC: "bb:bb:bb:bb:bb:00", HardIfname: "wlan0", Hops: 1},
-			{OrigMAC: "cc:cc:cc:cc:cc:00", NextHopMAC: "bb:bb:bb:bb:bb:00", HardIfname: "wlan0", Hops: 2},
+			{OrigMAC: "bb:bb:bb:bb:bb:00", NextHopMAC: "bb:bb:bb:bb:bb:00", HardIfname: "wlh0", Hops: 1},
+			{OrigMAC: "cc:cc:cc:cc:cc:00", NextHopMAC: "bb:bb:bb:bb:bb:00", HardIfname: "wlh0", Hops: 2},
 		},
 	}}
 
@@ -714,7 +714,7 @@ func TestGetMeshTopology_DedupesSelfAcrossAliasedVisEntries(t *testing.T) {
 // with different primaries and no shared secondary list collapse to one
 // MeshNode when they resolve to the same base hostname. This is the
 // common multi-radio-node case: each interface publishes its own vis
-// entry (bat0, eth0, wlan0) carrying a distinct MAC, but all three
+// entry (bat0, eth0, wlh0) carrying a distinct MAC, but all three
 // belong to the same physical device identified by bat-hosts name
 // "BCM2711-1003".
 func TestGetMeshTopology_DedupesByHostname(t *testing.T) {
@@ -735,11 +735,11 @@ func TestGetMeshTopology_DedupesByHostname(t *testing.T) {
 		Originators: []batmanadv.OriginatorEntry{
 			{
 				OrigMAC: "bb:bb:bb:bb:bb:01", OrigHostname: "BCM2711-1003_bat0",
-				NextHopMAC: "bb:bb:bb:bb:bb:01", HardIfname: "wlan0", Hops: 1,
+				NextHopMAC: "bb:bb:bb:bb:bb:01", HardIfname: "wlh0", Hops: 1,
 			},
 			{
 				OrigMAC: "bb:bb:bb:bb:bb:02", OrigHostname: "BCM2711-1003_eth0",
-				NextHopMAC: "bb:bb:bb:bb:bb:02", HardIfname: "wlan0", Hops: 1,
+				NextHopMAC: "bb:bb:bb:bb:bb:02", HardIfname: "wlh0", Hops: 1,
 			},
 		},
 	}}
@@ -836,7 +836,7 @@ func (f *fakeNeighborsProvider) All() map[string]*batmanadv.MeshNeighborsRecord 
 // canonical regression test for the BCM2711-fc8e → BCM2711-fc96 bug:
 // fc8e is an RF peer of fc96 (the gateway), but without gossip the
 // handler would render fc8e as its own remote segment. With gossip,
-// fc96's record says fc8e is on wlan0 → fc8e lives in fc96's remote
+// fc96's record says fc8e is on wlh0 → fc8e lives in fc96's remote
 // mesh component and inherits fc96 as its gateway.
 func TestGetMeshTopology_GossipClassifiesNodeBehindRemoteGateway(t *testing.T) {
 	const (
@@ -865,18 +865,18 @@ func TestGetMeshTopology_GossipClassifiesNodeBehindRemoteGateway(t *testing.T) {
 		},
 	}}
 
-	// fc96 publishes gossip stating fc8e is an RF peer on wlan0.
+	// fc96 publishes gossip stating fc8e is an RF peer on wlh0.
 	gwPayload := &netv1.MeshNeighbors{
 		PrimaryMac: gwMAC,
 		Neighbors: []*netv1.MeshNeighbor{
-			{Mac: behMAC, HardIfname: "wlan0", Blos: false},
+			{Mac: behMAC, HardIfname: "wlh0", Blos: false},
 			{Mac: selfMAC, HardIfname: "vxlan0", Blos: true},
 		},
 	}
 	behPayload := &netv1.MeshNeighbors{
 		PrimaryMac: behMAC,
 		Neighbors: []*netv1.MeshNeighbor{
-			{Mac: gwMAC, HardIfname: "wlan0", Blos: false},
+			{Mac: gwMAC, HardIfname: "wlh0", Blos: false},
 		},
 	}
 
@@ -936,7 +936,7 @@ func TestGetMeshTopology_GossipCoverageReflectsPublishers(t *testing.T) {
 	orig := &fakeOrigTopology{snap: &batmanadv.OriginatorTopology{
 		SelfMAC: selfMAC,
 		Originators: []batmanadv.OriginatorEntry{
-			{OrigMAC: synthMAC, NextHopMAC: synthMAC, HardIfname: "wlan0", Hops: 1},
+			{OrigMAC: synthMAC, NextHopMAC: synthMAC, HardIfname: "wlh0", Hops: 1},
 		},
 	}}
 
@@ -1000,7 +1000,7 @@ func TestGetMeshTopology_GossipHostnameFallback(t *testing.T) {
 				Hostname:    sharedHost,
 				CollectedAt: timestamppb.New(collected),
 				Neighbors: []*netv1.MeshNeighbor{
-					{Mac: "some-rf-peer", HardIfname: "wlan0"},
+					{Mac: "some-rf-peer", HardIfname: "wlh0"},
 				},
 			},
 			SourceMac: "f2:20:f9:84:c3:67",
@@ -1054,15 +1054,15 @@ func TestGetMeshTopology_MarksBatctlGatewaysWithIsGateway(t *testing.T) {
 	orig := &fakeOrigTopology{snap: &batmanadv.OriginatorTopology{
 		SelfMAC: selfMAC,
 		Originators: []batmanadv.OriginatorEntry{
-			{OrigMAC: gwMAC, OrigHostname: "BCM2711-1003_bat0", NextHopMAC: gwMAC, HardIfname: "wlan0", Hops: 1},
-			{OrigMAC: peerMAC, OrigHostname: "BCM2711-88ba_phy2-mesh0", NextHopMAC: peerMAC, HardIfname: "wlan0", Hops: 1},
+			{OrigMAC: gwMAC, OrigHostname: "BCM2711-1003_bat0", NextHopMAC: gwMAC, HardIfname: "wlh0", Hops: 1},
+			{OrigMAC: peerMAC, OrigHostname: "BCM2711-88ba_phy2-mesh0", NextHopMAC: peerMAC, HardIfname: "wlh0", Hops: 1},
 		},
 	}}
 
 	svc := newMeshTopologyService(vis, orig, nil)
 	svc.GetMeshGateways = func(_ string) (*batmanadv.Gateways, error) {
 		return &batmanadv.Gateways{
-			{OrigAddress: gwMAC, HardIfname: "wlan0", Best: true, Throughput: 100000},
+			{OrigAddress: gwMAC, HardIfname: "wlh0", Best: true, Throughput: 100000},
 		}, nil
 	}
 
@@ -1100,7 +1100,7 @@ func TestGetMeshTopology_GossipDerivedGatewayFlag(t *testing.T) {
 	orig := &fakeOrigTopology{snap: &batmanadv.OriginatorTopology{
 		SelfMAC: selfMAC,
 		Originators: []batmanadv.OriginatorEntry{
-			{OrigMAC: gwMAC, NextHopMAC: gwMAC, HardIfname: "wlan0", Hops: 1},
+			{OrigMAC: gwMAC, NextHopMAC: gwMAC, HardIfname: "wlh0", Hops: 1},
 			{OrigMAC: remoteMAC, NextHopMAC: gwMAC, HardIfname: "vxlan0", Hops: 2},
 		},
 	}}
@@ -1115,7 +1115,7 @@ func TestGetMeshTopology_GossipDerivedGatewayFlag(t *testing.T) {
 		Hostname:    "gw",
 		CollectedAt: timestamppb.New(collected),
 		Neighbors: []*netv1.MeshNeighbor{
-			{Mac: selfMAC, HardIfname: "wlan0", ThroughputKbps: 50000},
+			{Mac: selfMAC, HardIfname: "wlh0", ThroughputKbps: 50000},
 			{Mac: remoteMAC, HardIfname: "vxlan0", Blos: true, ThroughputKbps: 20000},
 		},
 	}
@@ -1176,7 +1176,7 @@ func TestGetMeshTopology_RedirectsBlosEdgeThroughLocalGateway(t *testing.T) {
 	orig := &fakeOrigTopology{snap: &batmanadv.OriginatorTopology{
 		SelfMAC: selfMAC,
 		Originators: []batmanadv.OriginatorEntry{
-			{OrigMAC: gwMAC, NextHopMAC: gwMAC, HardIfname: "wlan0", Hops: 1},
+			{OrigMAC: gwMAC, NextHopMAC: gwMAC, HardIfname: "wlh0", Hops: 1},
 			{OrigMAC: remoteMAC, NextHopMAC: remoteMAC, HardIfname: "vxlan0", Hops: 1},
 		},
 	}}
@@ -1188,7 +1188,7 @@ func TestGetMeshTopology_RedirectsBlosEdgeThroughLocalGateway(t *testing.T) {
 		PrimaryMac:  gwMAC,
 		CollectedAt: timestamppb.New(collected),
 		Neighbors: []*netv1.MeshNeighbor{
-			{Mac: selfMAC, HardIfname: "wlan0", ThroughputKbps: 50000},
+			{Mac: selfMAC, HardIfname: "wlh0", ThroughputKbps: 50000},
 			{Mac: remoteMAC, HardIfname: "vxlan0", Blos: true, ThroughputKbps: 30000},
 		},
 	}
@@ -1242,7 +1242,7 @@ func TestGetMeshTopology_RedirectsBlosEdgeThroughLocalGateway(t *testing.T) {
 // happened when stripIfaceSuffix was made too narrow. The bat-hosts
 // fixture (testfixtures/batman-adv/bat-hosts) is the source of truth
 // for the suffix shapes that appear in the field — phy0-mesh0,
-// phy2-mesh0, br-ahwlan, wlan-10-04, mesh0, vxlan0, bat0. Every
+// phy2-mesh0, br-ahwlan, wlh-10-04, mesh0, vxlan0, bat0. Every
 // node.Hostname rendered by the handler must come out the way
 // `shortHostname` expects: base name only, no iface suffix.
 //
@@ -1368,7 +1368,7 @@ func TestGetMeshTopology_GossipInterfaceMacBridgesBLOSMultiMesh(t *testing.T) {
 				CollectedAt:   timestamppb.New(collected),
 				InterfaceMacs: []string{payloadPrimary, visPrimary, envelopeMAC},
 				Neighbors: []*netv1.MeshNeighbor{
-					{Mac: "11:11:11:11:11:11", HardIfname: "wlan0"},
+					{Mac: "11:11:11:11:11:11", HardIfname: "wlh0"},
 				},
 			},
 			SourceMac: envelopeMAC,
@@ -1551,12 +1551,12 @@ func TestGetMeshTopology_GossipMetricsPopulateEdges(t *testing.T) {
 			{Mac: gwMAC, HardIfname: "vxlan0", Blos: true, ThroughputKbps: 6000},
 		},
 	}
-	// Gateway sees behMAC over wlan0 at 48 Mbps.
+	// Gateway sees behMAC over wlh0 at 48 Mbps.
 	gwPayload := &netv1.MeshNeighbors{
 		PrimaryMac: gwMAC,
 		Algorithm:  15,
 		Neighbors: []*netv1.MeshNeighbor{
-			{Mac: behMAC, HardIfname: "wlan0", Blos: false, ThroughputKbps: 48000},
+			{Mac: behMAC, HardIfname: "wlh0", Blos: false, ThroughputKbps: 48000},
 			{Mac: selfMAC, HardIfname: "vxlan0", Blos: true, ThroughputKbps: 6200},
 		},
 	}
@@ -1564,7 +1564,7 @@ func TestGetMeshTopology_GossipMetricsPopulateEdges(t *testing.T) {
 		PrimaryMac: behMAC,
 		Algorithm:  15,
 		Neighbors: []*netv1.MeshNeighbor{
-			{Mac: gwMAC, HardIfname: "wlan0", Blos: false, ThroughputKbps: 47800},
+			{Mac: gwMAC, HardIfname: "wlh0", Blos: false, ThroughputKbps: 47800},
 		},
 	}
 
@@ -1637,14 +1637,14 @@ func TestGetMeshTopology_GossipMetricsBATMANIV(t *testing.T) {
 		PrimaryMac: selfMAC,
 		Algorithm:  4, // BATMAN_IV
 		Neighbors: []*netv1.MeshNeighbor{
-			{Mac: peerMAC, HardIfname: "wlan0", Blos: false, Tq: 255}, // perfect TQ → 255/255 = 1.0
+			{Mac: peerMAC, HardIfname: "wlh0", Blos: false, Tq: 255}, // perfect TQ → 255/255 = 1.0
 		},
 	}
 	peerPayload := &netv1.MeshNeighbors{
 		PrimaryMac: peerMAC,
 		Algorithm:  4,
 		Neighbors: []*netv1.MeshNeighbor{
-			{Mac: selfMAC, HardIfname: "wlan0", Blos: false, Tq: 200}, // 255/200 = 1.275
+			{Mac: selfMAC, HardIfname: "wlh0", Blos: false, Tq: 200}, // 255/200 = 1.275
 		},
 	}
 

--- a/internal/openmanet/server/handlers/network_interface_test.go
+++ b/internal/openmanet/server/handlers/network_interface_test.go
@@ -343,7 +343,7 @@ func TestLinkTypeMapping_AllTypes(t *testing.T) {
 			infos: []network.NetworkInterfaceInfo{
 				{Name: "br0", LinkType: network.LinkTypeBridge, State: network.OperStateUp},
 				{Name: "eth0", LinkType: network.LinkTypeEthernet, State: network.OperStateDown},
-				{Name: "wlan0", LinkType: network.LinkTypeWiFiAP, State: network.OperStateUp},
+				{Name: "wlh0", LinkType: network.LinkTypeWiFiAP, State: network.OperStateUp},
 				{Name: "phy1", LinkType: network.LinkTypeHaLowMesh},
 				{Name: "bat0", LinkType: network.LinkTypeBatman},
 				{Name: "lo", LinkType: network.LinkTypeLoopback},

--- a/internal/openmanet/server/handlers/setup.go
+++ b/internal/openmanet/server/handlers/setup.go
@@ -443,7 +443,7 @@ func (s *SetupService) collectEthernetPorts() []string {
 
 // isLikelyEthernetPort returns true for interface names that look
 // like physical ethernet ports. Conservative heuristic: starts with
-// "eth", "lan", "en", or matches "wan*". Excludes wireless (wlan*)
+// "eth", "lan", "en", or matches "wan*". Excludes wireless (wlan*, wlh*)
 // and bridges (br*) and batman (bat*, batmesh*).
 func isLikelyEthernetPort(name string) bool {
 	if name == "" {
@@ -452,6 +452,7 @@ func isLikelyEthernetPort(name string) bool {
 
 	switch {
 	case strings.HasPrefix(name, "wlan"),
+		strings.HasPrefix(name, "wlh"),
 		strings.HasPrefix(name, "br"),
 		strings.HasPrefix(name, "bat"),
 		strings.HasPrefix(name, "lo"),

--- a/internal/openmanet/server/handlers/setup_test.go
+++ b/internal/openmanet/server/handlers/setup_test.go
@@ -332,6 +332,7 @@ func TestGetSetupStatus_EthernetPortsFiltered(t *testing.T) {
 			{Name: "eth0"},
 			{Name: "eth1"},
 			{Name: "wlan0"},      // filtered
+			{Name: "wlh0"},       // filtered (Morse HaLow)
 			{Name: "br-lan"},     // filtered
 			{Name: "lo"},         // filtered
 			{Name: "tailscale0"}, // filtered

--- a/internal/openmanet/server/handlers/validation_test.go
+++ b/internal/openmanet/server/handlers/validation_test.go
@@ -49,7 +49,7 @@ func TestValidation_GetWirelessInterfaceRequest_EmptyName(t *testing.T) {
 func TestValidation_GetWirelessInterfaceRequest_ValidName(t *testing.T) {
 	v := newValidator(t)
 
-	err := v.Validate(&serviceproto.GetWirelessInterfaceRequest{Name: "wlan0"})
+	err := v.Validate(&serviceproto.GetWirelessInterfaceRequest{Name: "wlh0"})
 	assert.NoError(t, err)
 }
 

--- a/internal/openmanet/server/handlers/wireless_test.go
+++ b/internal/openmanet/server/handlers/wireless_test.go
@@ -58,7 +58,7 @@ func TestGetWirelessInterface_NoName_ReturnsLast(t *testing.T) {
 	// When Name is empty the handler iterates all interfaces and returns the
 	// last one it encounters (no early break in the current implementation).
 	ifaces := []*wifi.Interface{
-		makeInterface("wlan0", wifi.InterfaceTypeStation),
+		makeInterface("wlh0", wifi.InterfaceTypeStation),
 		makeInterface("mesh0", wifi.InterfaceTypeMeshPoint),
 	}
 	svc := newInterfaceService(&fakeWireless{interfaces: ifaces})
@@ -71,15 +71,15 @@ func TestGetWirelessInterface_NoName_ReturnsLast(t *testing.T) {
 
 func TestGetWirelessInterface_ByName(t *testing.T) {
 	ifaces := []*wifi.Interface{
-		makeInterface("wlan0", wifi.InterfaceTypeStation),
+		makeInterface("wlh0", wifi.InterfaceTypeStation),
 		makeInterface("mesh0", wifi.InterfaceTypeMeshPoint),
 	}
 	svc := newInterfaceService(&fakeWireless{interfaces: ifaces})
 
-	resp, err := svc.GetWirelessInterface(context.Background(), &serviceproto.GetWirelessInterfaceRequest{Name: "wlan0"})
+	resp, err := svc.GetWirelessInterface(context.Background(), &serviceproto.GetWirelessInterfaceRequest{Name: "wlh0"})
 	require.NoError(t, err)
 	require.NotNil(t, resp.GetInterface())
-	assert.Equal(t, "wlan0", resp.GetInterface().GetName())
+	assert.Equal(t, "wlh0", resp.GetInterface().GetName())
 }
 
 func TestGetWirelessInterface_NotFound(t *testing.T) {
@@ -95,7 +95,7 @@ func TestGetWirelessInterface_NotFound(t *testing.T) {
 func TestGetWirelessInterface_Error(t *testing.T) {
 	svc := newInterfaceService(&fakeWireless{interfacesErr: errors.New("iw failure")})
 
-	_, err := svc.GetWirelessInterface(context.Background(), &serviceproto.GetWirelessInterfaceRequest{Name: "wlan0"})
+	_, err := svc.GetWirelessInterface(context.Background(), &serviceproto.GetWirelessInterfaceRequest{Name: "wlh0"})
 	require.Error(t, err)
 }
 

--- a/internal/util/board/getters.go
+++ b/internal/util/board/getters.go
@@ -45,7 +45,7 @@ func (n *Network) GetLan() Lan {
 
 // Lan getters
 
-// GetDevice returns the network device name (e.g., "eth0", "wlan0").
+// GetDevice returns the network device name (e.g., "eth0", "wlh0").
 func (l *Lan) GetDevice() string {
 	return l.Device
 }

--- a/internal/util/board/getters_test.go
+++ b/internal/util/board/getters_test.go
@@ -118,14 +118,14 @@ func TestNetworkGetters(t *testing.T) {
 
 func TestLanGetters(t *testing.T) {
 	lan := Lan{
-		Device:   "wlan0",
+		Device:   "wlh0",
 		Protocol: "static",
 		Ipaddr:   "10.0.0.1",
 		Netmask:  "255.0.0.0",
 	}
 
-	if lan.GetDevice() != "wlan0" {
-		t.Errorf("Expected device 'wlan0', got '%s'", lan.GetDevice())
+	if lan.GetDevice() != "wlh0" {
+		t.Errorf("Expected device 'wlh0', got '%s'", lan.GetDevice())
 	}
 
 	if lan.GetProtocol() != "static" {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -19,8 +19,8 @@ func TestInterfaceWithoutBridge(t *testing.T) {
 		},
 		{
 			name:      "bridge interface with br- prefix and multiple parts",
-			iface:     "br-wlan0",
-			want:      "wlan0",
+			iface:     "br-wlh0",
+			want:      "wlh0",
 			wantError: false,
 		},
 		{

--- a/testfixtures/batman-adv/bat-hosts
+++ b/testfixtures/batman-adv/bat-hosts
@@ -2,21 +2,21 @@
 ### /!\ This file is overwritten every 5 minutes /!\
 ### (To keep manual changes, replace /etc/bat-hosts symlink with a static file)
 # Node 0a:d7:37:78:2d:3e
-3c:22:7f:37:4c:0c BCM2711-97d6_wlan0
+3c:22:7f:37:4c:0c BCM2711-97d6_wlh0
 9c:ef:d5:f9:80:4d BCM2711-97d6_phy2-mesh0
 2c:cf:67:6a:97:d6 BCM2711-97d6_eth0
 0a:d7:37:78:2d:3e BCM2711-97d6_bat0
-2c:cf:67:6a:97:d9 BCM2711-97d6_wlan-97-d9
+2c:cf:67:6a:97:d9 BCM2711-97d6_wlh-97-d9
 
 # Node 2c:cf:67:b8:88:ba
 2e:2e:16:62:15:66 BCM2711-88ba_bat0
 2c:cf:67:b8:88:ba BCM2711-88ba_br-ahwlan
-bc:2a:33:96:b1:84 BCM2711-88ba_wlan0
+bc:2a:33:96:b1:84 BCM2711-88ba_wlh0
 9c:ef:d5:f9:9e:02 BCM2711-88ba_phy2-mesh0
 
 # Node 2c:cf:67:bb:10:03
-f4:ab:5c:df:3e:91 BCM2711-1003_wlan0
-2c:cf:67:bb:10:04 BCM2711-1003_wlan-10-04
+f4:ab:5c:df:3e:91 BCM2711-1003_wlh0
+2c:cf:67:bb:10:04 BCM2711-1003_wlh-10-04
 32:0d:d8:c7:f0:82 BCM2711-1003_bat0
 2c:cf:67:bb:10:03 BCM2711-1003_br-ahwlan
 00:0a:52:0b:7d:ae BCM2711-1003_phy1-mesh0
@@ -28,8 +28,8 @@ f4:ab:5c:df:3e:91 BCM2711-1003_wlan0
 00:c0:ca:b6:5c:56 HaLow-R-b65c57_br-ahwlan
 
 # Node e4:5f:01:df:f8:fd
-e4:5f:01:df:f8:fe BCM2711-f8fd_wlan-f8-fe
-3c:22:7f:37:4d:e7 BCM2711-f8fd_wlan0
+e4:5f:01:df:f8:fe BCM2711-f8fd_wlh-f8-fe
+3c:22:7f:37:4d:e7 BCM2711-f8fd_wlh0
 92:bc:bf:c5:2b:97 BCM2711-f8fd_bat0
 00:0a:52:08:ae:80 BCM2711-f8fd_phy1-mesh0
 e4:5f:01:df:f8:fd BCM2711-f8fd_br-ahwlan

--- a/testfixtures/iwinfo/devices.json
+++ b/testfixtures/iwinfo/devices.json
@@ -1,7 +1,7 @@
 {
   "devices": [
     "phy1-mesh0",
-    "wlan-10-04",
-    "wlan0"
+    "wlh-10-04",
+    "wlh0"
   ]
 }


### PR DESCRIPTION
## Summary

Two changesets plus one pre-existing chore commit:

### 1. Hardware audio init resilience (OpenVLM)

On OpenVLM hardware, the ALSA dmix slave start can fail transiently at boot (`miniaudio: Broken pipe` — EPIPE from `snd_pcm_start` inside `snd_pcm_dmix_open`), and the dongle is hot-pluggable. Previously one failed init meant no mic/speaker until daemon restart.

- **Startup retry**: `initAudioIO` retries malgo init up to 3 times, 750 ms apart, context-aware (`86cf4a2`)
- **In-run recovery**: the `Run` loop re-attempts init every 10 s until success — on the existing goroutine, no new goroutine; ticker disarmed after success. Re-runs ALSA card detection when `ALSA_CARD` is unset, so plugging the dongle in later brings audio up without a restart (`25bf02d`)
- **Concurrency**: broadcast stream moved behind RWMutex accessors (`Broadcast()`/`SetBroadcast`) since recovery can install it while the instrumentation snapshot goroutine reads it (`21effb7`)
- **Log hygiene**: first recovery failure logs Warn, repeats Debug; detection throttled to ~1/min — no log flood on dongle-less devices. `alsa_card` field added to audio init logs (`1cd183a`, `6dc50ef`)
- Docs in `internal/comms/README.md` (`682f039`)

### 2. Morse Micro device prefix rename wlan -> wlh (`1f62bd7`, `896b24d`)

- Functional: frontend wifi fallback globs both `wlan*` and `wlh*`; `isLikelyEthernetPort` excludes `wlh*` explicitly
- Cosmetic: comments and test fixtures renamed across Go + frontend tests
- Deliberately untouched: `ahwlan`/`br-ahwlan` (UCI network name, not a device prefix), board.json `wlan` schema key, `proto/` and `internal/alfred` submodules (need their own commits if wanted)

### Also included

- `36472b4` chore: add plugin (pre-existing on branch — enables the caveman plugin in checked-in `.claude/settings.json`; flagging since it affects all contributors)
- `3661c72` fix: remove volume mount in devcontainer (pre-existing)

## Testing

- `make test` all packages green; `make test-race` clean; `make integration-test` green
- Frontend: 584/584 Vitest tests pass; lint 0 errors
- `golangci-lint` 0 issues
- 13 new Go tests (retry bounds, ctx cancellation, recovery ticker lifecycle, detection gate — all hermetic), plus wlh heuristic test cases

Known environment note: `make lint-go`'s `--fix` auto-applies a `fieldalignment` restructure to `internal/comms/config.go` that strips mutex-contract doc comments — pre-existing repo/tooling condition, that diff is deliberately not committed. `make test-frontend` has a pre-existing devcontainer pnpm/corepack mismatch; tests run via direct `pnpm run test:coverage`.