### PR TITLE
fix: disable mesh learning with mesh forwarding

### DIFF
--- a/internal/network/uci_mesh11sd.go
+++ b/internal/network/uci_mesh11sd.go
@@ -22,6 +22,9 @@ type UCIMesh11sdMeshParams struct {
 	// always the case in this codebase, since batman-adv is mandatory)
 	// and "1" if the device falls back to in-driver mesh forwarding.
 	MeshFwding string `uci:"option mesh_fwding"`
+	// MeshNoLearn is "1" when batman-adv owns forwarding so the kernel
+	// mesh does not learn forwarding state independently.
+	MeshNoLearn string `uci:"option mesh_nolearn"`
 }
 
 // UCIMesh11sdConfigReader wraps go-uci with the same shape as the
@@ -87,6 +90,10 @@ func GetMesh11sdMeshParamsWithReader(reader ConfigReader) (*UCIMesh11sdMeshParam
 		cfg.MeshFwding = v[0]
 	}
 
+	if v, ok := reader.Get(mesh11sdConfigName, mesh11sdMeshParamSection, "mesh_nolearn"); ok && len(v) > 0 {
+		cfg.MeshNoLearn = v[0]
+	}
+
 	return cfg, nil
 }
 
@@ -99,11 +106,16 @@ func SetMeshGateAnnouncements(reader ConfigReader, value string) error {
 	return setMesh11sdMeshParam(reader, "mesh_gate_announcements", value)
 }
 
-// SetMeshFwding writes mesh11sd.mesh_params.mesh_fwding. The setup
-// wizard always passes "0" because batman-adv is mandatory and
-// in-driver forwarding would create routing loops. Does not commit.
-func SetMeshFwding(reader ConfigReader, value string) error {
-	return setMesh11sdMeshParam(reader, "mesh_fwding", value)
+// DisableMeshForwarding configures mesh11sd so batman-adv exclusively owns
+// forwarding. mesh_fwding and mesh_nolearn must be written together to avoid
+// the kernel mesh learning forwarding state that belongs to batman-adv. Does
+// not commit.
+func DisableMeshForwarding(reader ConfigReader) error {
+	if err := setMesh11sdMeshParam(reader, "mesh_fwding", "0"); err != nil {
+		return err
+	}
+
+	return setMesh11sdMeshParam(reader, "mesh_nolearn", "1")
 }
 
 // SetMesh11sdSetupEnabled writes mesh11sd.setup.enabled. Required for

--- a/internal/network/uci_mesh11sd_test.go
+++ b/internal/network/uci_mesh11sd_test.go
@@ -24,6 +24,7 @@ func newMesh11sdMock(t *testing.T) *mockConfigReader {
 	require.NoError(t, m.AddSection("mesh11sd", "mesh_params", "mesh11sd"))
 	require.NoError(t, m.SetType("mesh11sd", "setup", "enabled", uci.TypeOption, "0"))
 	require.NoError(t, m.SetType("mesh11sd", "mesh_params", "mesh_fwding", uci.TypeOption, "1"))
+	require.NoError(t, m.SetType("mesh11sd", "mesh_params", "mesh_nolearn", uci.TypeOption, "0"))
 	require.NoError(t, m.SetType("mesh11sd", "mesh_params", "mesh_gate_announcements", uci.TypeOption, "0"))
 
 	m.commitCalled = false
@@ -40,6 +41,7 @@ func TestGetMesh11sdMeshParamsWithReader(t *testing.T) {
 
 	assert.Equal(t, "0", got.MeshGateAnnouncements)
 	assert.Equal(t, "1", got.MeshFwding)
+	assert.Equal(t, "0", got.MeshNoLearn)
 }
 
 func TestSetMeshGateAnnouncements_FlipsToOne(t *testing.T) {
@@ -65,20 +67,21 @@ func TestSetMeshGateAnnouncements_RejectsInvalid(t *testing.T) {
 	}
 }
 
-func TestSetMeshFwding_FlipsToZero(t *testing.T) {
+func TestDisableMeshForwarding_WritesRequiredPair(t *testing.T) {
 	m := newMesh11sdMock(t)
 
-	require.NoError(t, SetMeshFwding(m, "0"))
+	require.NoError(t, DisableMeshForwarding(m))
 
-	v, ok := m.Get("mesh11sd", "mesh_params", "mesh_fwding")
+	fwding, ok := m.Get("mesh11sd", "mesh_params", "mesh_fwding")
 	require.True(t, ok)
-	require.Len(t, v, 1)
-	assert.Equal(t, "0", v[0])
-}
+	assert.Equal(t, []string{"0"}, fwding)
 
-func TestSetMeshFwding_RejectsInvalid(t *testing.T) {
-	m := newMesh11sdMock(t)
-	assert.Error(t, SetMeshFwding(m, "yes"))
+	noLearn, ok := m.Get("mesh11sd", "mesh_params", "mesh_nolearn")
+	require.True(t, ok)
+	assert.Equal(t, []string{"1"}, noLearn)
+
+	// Helper does not commit; the wizard handler batches.
+	assert.Equal(t, 0, m.commitCount)
 }
 
 func TestSetMesh11sdSetupEnabled_FlipsToOne(t *testing.T) {
@@ -105,7 +108,7 @@ func TestSetMesh11sdHelpers_PropagateSetError(t *testing.T) {
 		fn   func(*mockConfigReader) error
 	}{
 		{"MeshGateAnnouncements", func(m *mockConfigReader) error { return SetMeshGateAnnouncements(m, "1") }},
-		{"MeshFwding", func(m *mockConfigReader) error { return SetMeshFwding(m, "0") }},
+		{"MeshForwarding", func(m *mockConfigReader) error { return DisableMeshForwarding(m) }},
 		{"SetupEnabled", func(m *mockConfigReader) error { return SetMesh11sdSetupEnabled(m, "1") }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/openmanet/server/handlers/setup_compat_test.go
+++ b/internal/openmanet/server/handlers/setup_compat_test.go
@@ -501,13 +501,16 @@ func TestCompat_Mesh11sdGateAnnouncements_Point(t *testing.T) {
 		"mesh point must NOT announce itself as a gate")
 }
 
-// TestCompat_Mesh11sdFwdingDisabled asserts mesh_fwding=0 (batman-adv
-// owns forwarding when batman is in play, which it always is here).
-func TestCompat_Mesh11sdFwdingDisabled(t *testing.T) {
+// TestCompat_Mesh11sdForwardingDisabled asserts the required mesh11sd pair for
+// making batman-adv the exclusive owner of forwarding.
+func TestCompat_Mesh11sdForwardingDisabled(t *testing.T) {
 	tr := runScenarioApply(t, gateRouterEthProfile())
 	assert.Equal(t, "0",
 		tr.getOne("mesh11sd", "mesh_params", "mesh_fwding"),
 		"mesh11sd.mesh_fwding must be 0 — batman-adv handles forwarding")
+	assert.Equal(t, "1",
+		tr.getOne("mesh11sd", "mesh_params", "mesh_nolearn"),
+		"mesh11sd.mesh_nolearn must be 1 when mesh_fwding is disabled")
 }
 
 // TestCompat_HostnameWritten asserts the wizard invokes the

--- a/internal/openmanet/server/handlers/setup_phases.go
+++ b/internal/openmanet/server/handlers/setup_phases.go
@@ -1194,12 +1194,13 @@ func batmanGwModeForRole(role setupv1.MeshRole) string {
 
 // ── Phase 11: mesh11sd announcements ─────────────────────────────────────────
 
-// runMesh11sd writes mesh_fwding=0 (batman-adv handles forwarding)
-// and mesh_gate_announcements per the user's role choice.
+// runMesh11sd writes mesh_fwding=0 and mesh_nolearn=1 so batman-adv
+// exclusively handles forwarding, then configures mesh_gate_announcements
+// per the user's role choice.
 func (s *SetupService) runMesh11sd(_ context.Context, stream applySetupStream, profile *setupv1.MeshNodeProfile) error {
 	return s.runPhase(stream, setupv1.ApplySetupResponse_PHASE_MESH11SD,
 		"writing mesh11sd announcements", func() error {
-			if err := network.SetMeshFwding(s.UCI, "0"); err != nil {
+			if err := network.DisableMeshForwarding(s.UCI); err != nil {
 				return err
 			}
 

--- a/internal/openmanet/server/handlers/setup_test.go
+++ b/internal/openmanet/server/handlers/setup_test.go
@@ -1095,6 +1095,7 @@ func newFullSetupReader() *fakeConfigReader {
 	r.data["mesh11sd"]["setup"] = map[string][]string{"enabled": {"0"}}
 	r.data["mesh11sd"]["mesh_params"] = map[string][]string{
 		"mesh_fwding":             {"1"},
+		"mesh_nolearn":            {"0"},
 		"mesh_gate_announcements": {"0"},
 	}
 


### PR DESCRIPTION
## Summary

- replace the standalone `mesh_fwding` write with one helper that enforces `mesh_fwding=0` and `mesh_nolearn=1` together
- include `mesh_nolearn` in the editable mesh11sd parameter model
- add unit and setup compatibility coverage for the required pair

## Why

OpenMANET uses batman-adv for forwarding, so openmanetd already disables 802.11s forwarding with `mesh_fwding=0`. It left `mesh_nolearn=0`, however, allowing the kernel mesh to learn forwarding state independently. Setting `mesh_nolearn=1` alongside disabled mesh forwarding keeps batman-adv as the exclusive forwarding owner.

## Impact

Setup runs now overwrite the package default and stage both mesh11sd values together before the existing batched UCI commit.

## Validation

- `go test ./internal/network`
- `go test -race ./internal/network`
- `go vet ./internal/network`
- `golangci-lint run --timeout 5m ./internal/network/...` (0 issues)
- `git diff --check`

The full handler-package test build is blocked in this development host by an unchanged PAM dependency failing to resolve `C.RTLD_NEXT`; GitHub CI remains the full-package validation path.
