### PR TITLE
fix(comms): fixes from the hot-path review

### DIFF
--- a/docs/instrumentation-snapshot.md
+++ b/docs/instrumentation-snapshot.md
@@ -190,7 +190,7 @@ One entry per configured multicast talk group. The slice order mirrors
 | `rx_loopback` | count | Packets dropped by the loopback filter (own-IP suppression) before reaching the RTP parser. |
 | `rx_parse_errs` | count | Packets that failed `rtp.ParseIncoming`. Sustained nonzero deltas indicate a non-RTP sender aliasing the port. |
 | `rx_pushed` | count | Packets that `PushWithSSRC` accepted into the jitter buffer. In a healthy stream, `rx_pushed ≈ rx_pkts - rx_loopback - rx_parse_errs`. |
-| `rx_push_rejected` | count | Packets that `PushWithSSRC` rejected as stale-cursor, duplicate, or overflow. A sustained nonzero delta with `jitter.ssrc_resets` flat indicates a consumer-side cursor-advance bug or sender reordering. |
+| `rx_push_rejected` | count | Packets that `PushWithSSRC` rejected as stale-cursor, duplicate, overflow, or oversized (payload larger than the RFC 6716 1275-byte frame cap — a conforming Opus sender never produces these). A sustained nonzero delta with `jitter.ssrc_resets` flat indicates a consumer-side cursor-advance bug, sender reordering, or a non-Opus sender aliasing the port. |
 | `web_popped_skipped` | count | `webPlayoutLoop` observed the jitter buffer advancing past a missing sequence number (only happens when the buffer is half-full of out-of-order packets). Zero on the portaudio playout path. |
 | `jitter.overflows` | count | Incoming packets rejected because the jitter buffer was full. Sustained non-zero deltas across snapshots mean the receiver is behind the sender or the network is bursting. |
 | `jitter.ssrc_resets` | count | Mid-stream SSRC transitions the jitter buffer handled by resetting. High values (multiple per minute) suggest multiple talkers or sender restarts. |
@@ -199,7 +199,7 @@ One entry per configured multicast talk group. The slice order mirrors
 | `jitter.gap_runs_2_5` | count | Gap runs of 2–5 frames (40–100 ms). |
 | `jitter.gap_runs_6_10` | count | Gap runs of 6–10 frames (120–200 ms). |
 | `jitter.gap_runs_11_20` | count | Gap runs of 11–20 frames (220–400 ms). |
-| `jitter.gap_runs_21_50` | count | Gap runs of 21–50 frames (420 ms–1 s). Will only fire if `MaxDepth` is raised above 24. |
+| `jitter.gap_runs_21_50` | count | Gap runs of 21–50 frames (420 ms–1 s). Runs longer than 31 cannot occur at the current `MaxDepth` of 32. |
 | `jitter.gap_runs_over_50` | count | Gap runs of 51+ frames (>1 s). Will only fire if `MaxDepth` is raised above 50. |
 | `rx_gate.last_mark_unix_nano` | unix-nanoseconds | Timestamp of the most recent Mark call; 0 = never marked. |
 | `rx_gate.threshold_ns` | nanoseconds | Half-duplex receive window. Default is 400 ms. |

--- a/internal/comms/bench_test.go
+++ b/internal/comms/bench_test.go
@@ -298,9 +298,8 @@ func BenchmarkPlayoutOneFrame_Mock(b *testing.B) {
 	pc.SendEnabled.Store(true)
 	pc.ReceiveEnabled.Store(true)
 
-	rt := &CommsRuntime{
-		Decoder: &mockDecoder{returnN: audiopool.FrameSize},
-	}
+	pc.Decoder = &mockDecoder{returnN: audiopool.FrameSize}
+	rt := &CommsRuntime{}
 
 	jb := rtp.NewJitterBuffer(1, rtp.MaxDepth)
 	payload := make([]byte, 100)
@@ -349,8 +348,9 @@ func BenchmarkPlayoutOneFrame_Real(b *testing.B) {
 	pc := &PortChannel{cfg: McastPortConfig{Send: true, Receive: true}}
 	pc.SendEnabled.Store(true)
 	pc.ReceiveEnabled.Store(true)
+	pc.Decoder = dec
 
-	rt := &CommsRuntime{Decoder: dec}
+	rt := &CommsRuntime{}
 
 	jb := rtp.NewJitterBuffer(1, rtp.MaxDepth)
 	out := make([]int16, audiopool.FrameSize)
@@ -403,8 +403,9 @@ func BenchmarkPlayoutOneFrame_PLC(b *testing.B) {
 	pc := &PortChannel{cfg: McastPortConfig{Send: true, Receive: true}}
 	pc.SendEnabled.Store(true)
 	pc.ReceiveEnabled.Store(true)
+	pc.Decoder = dec
 
-	rt := &CommsRuntime{Decoder: dec}
+	rt := &CommsRuntime{}
 
 	// Prime the jitter buffer with a single push+pop so started=true and
 	// lastPush is recent; subsequent playoutOneFrame calls will hit conceal.

--- a/internal/comms/comms.go
+++ b/internal/comms/comms.go
@@ -40,9 +40,9 @@ const (
 	defaultCtrlSrc    string = "openvlm"
 )
 
-// ─── buildCodec ───────────────────────────────────────────────────────────────
+// ─── codec construction ──────────────────────────────────────────────────────
 
-func (cfg *CommsConfig) buildCodec() (codec.AudioEncoder, codec.AudioDecoder, error) {
+func (cfg *CommsConfig) buildEncoder() (codec.AudioEncoder, error) {
 	complexity := cfg.EncoderComplexity
 	if complexity <= 0 || complexity > 10 {
 		complexity = encoderComplexity
@@ -55,15 +55,33 @@ func (cfg *CommsConfig) buildCodec() (codec.AudioEncoder, codec.AudioDecoder, er
 
 	enc, err := codec.NewOpusEncoder(audiopool.SampleRate, audiopool.Channels, targetBitrate, complexity, perc)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	dec, err := codec.NewOpusDecoder(audiopool.SampleRate, audiopool.Channels)
-	if err != nil {
-		return nil, nil, err
+	return enc, nil
+}
+
+// buildPortDecoders allocates a private Opus decoder for every receive-capable
+// port. Decoders are stateful and NOT safe for concurrent use, and any number
+// of ports can be receive-enabled at once (each with its own playback thread),
+// so one decoder per port is a correctness requirement, not an optimization.
+// libopus decoder state is ~27 KB per instance — affordable even on the MIPS
+// targets at the default five talk groups.
+func buildPortDecoders(ports []*PortChannel) error {
+	for _, pc := range ports {
+		if pc.Receiver == nil {
+			continue
+		}
+
+		dec, err := codec.NewOpusDecoder(audiopool.SampleRate, audiopool.Channels)
+		if err != nil {
+			return fmt.Errorf("port decoder: %w", err)
+		}
+
+		pc.Decoder = dec
 	}
 
-	return enc, dec, nil
+	return nil
 }
 
 // sendToAllPorts sends an encoded RTP payload to every port where sendEnabled

--- a/internal/comms/comms_test.go
+++ b/internal/comms/comms_test.go
@@ -139,7 +139,7 @@ func TestPlayoutOneFrame_SuppressedDuringBroadcastOnSendPort(t *testing.T) {
 	}
 	rt.Broadcasting.Store(true)
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0xAA, 0xBB})
 
 	out := make([]int16, audiopool.FrameSize)
@@ -166,7 +166,7 @@ func TestPlayoutOneFrame_DecodesPayloadIntoOut(t *testing.T) {
 	dec := &mockDecoder{fillValue: 42, returnN: audiopool.FrameSize}
 	rt := &CommsRuntime{Decoder: dec}
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{1, 2, 3})
 
 	out := make([]int16, audiopool.FrameSize)
@@ -199,7 +199,7 @@ func TestPlayoutOneFrame_PLCFillsOut(t *testing.T) {
 	// Push and pop to set started=true and a recent lastPush; the next
 	// playoutOneFrame call will hit the conceal branch and call the decoder
 	// with a nil payload (PLC).
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0})
 	jb.PopReady()
 

--- a/internal/comms/comms_test.go
+++ b/internal/comms/comms_test.go
@@ -47,9 +47,9 @@ func TestReceiveLoop_ExitsOnContextCancel(t *testing.T) {
 	pc.SendEnabled.Store(true)
 	pc.ReceiveEnabled.Store(true)
 	pc.PlaybackBuffer = make(chan []int16, 8)
+	pc.Decoder = &mockDecoder{}
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{},
+		Ports: []*PortChannel{pc},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -87,9 +87,9 @@ func TestReceiveLoop_IngestsPackets(t *testing.T) {
 	pc.SendEnabled.Store(true)
 	pc.ReceiveEnabled.Store(true)
 	pc.PlaybackBuffer = make(chan []int16, 32)
+	pc.Decoder = &mockDecoder{returnN: int(rtp.FrameSamples)}
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{returnN: int(rtp.FrameSamples)},
+		Ports: []*PortChannel{pc},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -133,9 +133,9 @@ func TestPlayoutOneFrame_SuppressedDuringBroadcastOnSendPort(t *testing.T) {
 	pc.SendEnabled.Store(true)
 	pc.ReceiveEnabled.Store(true)
 
+	pc.Decoder = &mockDecoder{fillValue: 42, returnN: audiopool.FrameSize}
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{fillValue: 42, returnN: audiopool.FrameSize},
+		Ports: []*PortChannel{pc},
 	}
 	rt.Broadcasting.Store(true)
 
@@ -164,7 +164,8 @@ func TestPlayoutOneFrame_DecodesPayloadIntoOut(t *testing.T) {
 	pc.ReceiveEnabled.Store(true)
 
 	dec := &mockDecoder{fillValue: 42, returnN: audiopool.FrameSize}
-	rt := &CommsRuntime{Decoder: dec}
+	pc.Decoder = dec
+	rt := &CommsRuntime{}
 
 	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{1, 2, 3})
@@ -194,7 +195,8 @@ func TestPlayoutOneFrame_PLCFillsOut(t *testing.T) {
 	pc.ReceiveEnabled.Store(true)
 
 	dec := &mockDecoder{fillValue: 10, returnN: audiopool.FrameSize}
-	rt := &CommsRuntime{Decoder: dec}
+	pc.Decoder = dec
+	rt := &CommsRuntime{}
 
 	// Push and pop to set started=true and a recent lastPush; the next
 	// playoutOneFrame call will hit the conceal branch and call the decoder
@@ -245,28 +247,23 @@ func TestEncoderComplexity_DefaultIsMIPSFriendly(t *testing.T) {
 	}
 }
 
-// TestBuildCodec_UsesDefaultComplexity verifies that buildCodec falls back
-// to the package default when CommsConfig.EncoderComplexity is unset, and
-// that the default produces a working encoder/decoder pair.
-func TestBuildCodec_UsesDefaultComplexity(t *testing.T) {
+// TestBuildEncoder_UsesDefaultComplexity verifies that buildEncoder falls
+// back to the package default when CommsConfig.EncoderComplexity is unset,
+// and that the default produces a working encoder.
+func TestBuildEncoder_UsesDefaultComplexity(t *testing.T) {
 	cfg := &CommsConfig{Log: zerolog.Nop()}
 
-	enc, dec, err := cfg.buildCodec()
+	enc, err := cfg.buildEncoder()
 	if err != nil {
-		t.Fatalf("buildCodec with default complexity: %v", err)
+		t.Fatalf("buildEncoder with default complexity: %v", err)
 	}
 
 	if enc == nil {
-		t.Fatal("buildCodec returned nil encoder")
-	}
-
-	if dec == nil {
-		t.Fatal("buildCodec returned nil decoder")
+		t.Fatal("buildEncoder returned nil encoder")
 	}
 
 	t.Cleanup(func() {
 		_ = enc.Close()
-		_ = dec.Close()
 	})
 
 	// Smoke test: a single frame round-trip succeeds with the default
@@ -281,6 +278,43 @@ func TestBuildCodec_UsesDefaultComplexity(t *testing.T) {
 
 	if n <= 0 {
 		t.Fatalf("EncodeS16 produced %d bytes, want > 0", n)
+	}
+}
+
+// TestBuildPortDecoders_DistinctPerReceivePort verifies that every
+// receive-capable port gets its own decoder instance. Concurrent receive on
+// multiple talk groups is a designed capability, and each port's playback
+// callback runs on its own audio thread, so decoder state must never be
+// shared between ports.
+func TestBuildPortDecoders_DistinctPerReceivePort(t *testing.T) {
+	ports := []*PortChannel{
+		{Receiver: rtp.NewSwappableReceiver(newMockReader())},
+		{}, // send-only: no receive socket, no decoder needed
+		{Receiver: rtp.NewSwappableReceiver(newMockReader())},
+	}
+
+	if err := buildPortDecoders(ports); err != nil {
+		t.Fatalf("buildPortDecoders: %v", err)
+	}
+
+	t.Cleanup(func() {
+		for _, pc := range ports {
+			if pc.Decoder != nil {
+				_ = pc.Decoder.Close()
+			}
+		}
+	})
+
+	if ports[0].Decoder == nil || ports[2].Decoder == nil {
+		t.Fatal("every receive-capable port must get a decoder")
+	}
+
+	if ports[0].Decoder == ports[2].Decoder {
+		t.Fatal("ports must not share a decoder instance")
+	}
+
+	if ports[1].Decoder != nil {
+		t.Error("send-only port should not get a decoder")
 	}
 }
 
@@ -304,14 +338,13 @@ func TestBuildCodec_HonorsExplicitComplexity(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := &CommsConfig{Log: zerolog.Nop(), EncoderComplexity: tc.in}
 
-			enc, dec, err := cfg.buildCodec()
+			enc, err := cfg.buildEncoder()
 			if err != nil {
-				t.Fatalf("buildCodec(%d): %v", tc.in, err)
+				t.Fatalf("buildEncoder(%d): %v", tc.in, err)
 			}
 
 			t.Cleanup(func() {
 				_ = enc.Close()
-				_ = dec.Close()
 			})
 		})
 	}

--- a/internal/comms/config.go
+++ b/internal/comms/config.go
@@ -39,7 +39,6 @@ type BroadcastCapture interface {
 // incoming stream) and cleared by halfDuplexDecayLoop on a coarse 100 ms
 // ticker once every gate's window has expired.
 type CommsRuntime struct { //nolint:govet // fieldalignment: mu must sit directly above the broadcastStream field it guards (.claude/rules/concurrency.md); the pointer-scan-optimal layout would separate them.
-	Decoder         codec.AudioDecoder
 	Encoder         codec.AudioEncoder
 	FECAdapter      *FECAdapter
 	WebBridge       *webaudio.Bridge

--- a/internal/comms/integration_test.go
+++ b/internal/comms/integration_test.go
@@ -78,10 +78,10 @@ func newIntegrationReceiver(t *testing.T) (*CommsConfig, *PortChannel, *CommsRun
 	}
 	pc.SendEnabled.Store(true)
 	pc.ReceiveEnabled.Store(true)
+	pc.Decoder = &mockDecoder{fillValue: 1234, returnN: int(rtp.FrameSamples)}
 
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{fillValue: 1234, returnN: int(rtp.FrameSamples)},
+		Ports: []*PortChannel{pc},
 	}
 
 	cfg := &CommsConfig{Log: zerolog.Nop(), Loopback: true}

--- a/internal/comms/lifecycle.go
+++ b/internal/comms/lifecycle.go
@@ -283,9 +283,9 @@ func (cfg *CommsConfig) Start(ctx context.Context) error {
 	)
 
 	// ── codec ──────────────────────────────────────────────────────────────
-	enc, dec, err := cfg.buildCodec()
+	enc, err := cfg.buildEncoder()
 	if err != nil {
-		return fmt.Errorf("comms: failed to build Opus codec: %w", err)
+		return fmt.Errorf("comms: failed to build Opus encoder: %w", err)
 	}
 
 	// ── beep tones ─────────────────────────────────────────────────────────
@@ -308,10 +308,19 @@ func (cfg *CommsConfig) Start(ctx context.Context) error {
 		return fmt.Errorf("comms: failed to set up network: %w", netErr)
 	}
 
+	// Per-port decoders: allocated after buildNetwork so every
+	// receive-capable port (Receiver != nil) gets its own instance.
+	if decErr := buildPortDecoders(ports); decErr != nil {
+		for _, pc := range ports {
+			pc.closePartial()
+		}
+
+		return fmt.Errorf("comms: failed to build Opus decoders: %w", decErr)
+	}
+
 	// ── assemble runtime ───────────────────────────────────────────────────
 	rt := &CommsRuntime{
 		Encoder:         enc,
-		Decoder:         dec,
 		Ports:           ports,
 		BeepBufferStart: beepStart,
 		BeepBufferStop:  beepStop,

--- a/internal/comms/mocks_test.go
+++ b/internal/comms/mocks_test.go
@@ -240,6 +240,24 @@ func (m *mockReader) remaining() int {
 	return len(m.packets)
 }
 
+// ─── fakeErrReader ───────────────────────────────────────────────────────────
+
+// fakeErrReader is a PacketReader whose ReadFromUDP always fails with err.
+// reads counts attempts so tests can assert receiveLoop backs off instead of
+// busy-spinning on a permanently failing socket.
+type fakeErrReader struct {
+	err   error
+	reads atomic.Int64
+}
+
+func (f *fakeErrReader) ReadFromUDP(_ []byte) (int, *net.UDPAddr, error) {
+	f.reads.Add(1)
+
+	return 0, nil, f.err
+}
+
+func (f *fakeErrReader) Close() error { return nil }
+
 // ─── mockEventSource ─────────────────────────────────────────────────────────
 
 // mockEventSource satisfies control.EventSource. Pre-loaded events are sent

--- a/internal/comms/multiport_test.go
+++ b/internal/comms/multiport_test.go
@@ -305,9 +305,9 @@ func TestReceiveLoop_SkipsDeliveryWhenReceiveDisabled(t *testing.T) {
 	pc.ReceiveEnabled.Store(false) // ← disabled
 	pc.PlaybackBuffer = make(chan []int16, 8)
 
+	pc.Decoder = &mockDecoder{returnN: int(rtp.FrameSamples)}
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{returnN: int(rtp.FrameSamples)},
+		Ports: []*PortChannel{pc},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -387,7 +387,6 @@ func TestBeginTransmission_BeepSentToAllPorts(t *testing.T) {
 		Ports:           []*PortChannel{pc0, pc1},
 		BeepBufferStart: []int16{100, 200},
 		BeepBufferStop:  []int16{300, 400},
-		Decoder:         &mockDecoder{},
 	}
 	rt.SetBroadcast(&mockStream{})
 
@@ -434,9 +433,9 @@ func TestPlayoutOneFrame_ReceiveOnlyPortNotSuppressedDuringBroadcast(t *testing.
 	pc.SendEnabled.Store(false)
 	pc.ReceiveEnabled.Store(true)
 
+	pc.Decoder = &mockDecoder{fillValue: 42, returnN: audiopool.FrameSize}
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{fillValue: 42, returnN: audiopool.FrameSize},
+		Ports: []*PortChannel{pc},
 	}
 	rt.Broadcasting.Store(true) // simulate active broadcast on another port
 

--- a/internal/comms/multiport_test.go
+++ b/internal/comms/multiport_test.go
@@ -440,7 +440,7 @@ func TestPlayoutOneFrame_ReceiveOnlyPortNotSuppressedDuringBroadcast(t *testing.
 	}
 	rt.Broadcasting.Store(true) // simulate active broadcast on another port
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0xAA, 0xBB}) // prebuffer=1: immediately ready
 
 	cfg := &CommsConfig{Log: zerolog.Nop()}

--- a/internal/comms/port_channel.go
+++ b/internal/comms/port_channel.go
@@ -3,6 +3,7 @@ package comms
 import (
 	"sync/atomic"
 
+	"github.com/openmanet/openmanetd/internal/comms/codec"
 	"github.com/openmanet/openmanetd/internal/comms/control"
 	"github.com/openmanet/openmanetd/internal/comms/device"
 	"github.com/openmanet/openmanetd/internal/comms/rtp"
@@ -60,6 +61,15 @@ type McastPortState struct {
 // drains it before falling through to playoutOneFrame so beeps preempt one
 // frame of jitter-buffered audio.
 type PortChannel struct {
+	// Decoder is this port's private Opus decoder, allocated by
+	// buildPortDecoders for every receive-capable port. It MUST NOT be
+	// shared between ports: each port's malgo playback callback runs on its
+	// own audio thread and any number of ports can be receive-enabled
+	// concurrently, so a shared decoder would be a C-level data race inside
+	// libopus — and even serialized, interleaving two RTP streams through
+	// one stateful decoder corrupts the prediction state of both. Per-port
+	// state also keeps PLC continuity correct per stream.
+	Decoder           codec.AudioDecoder
 	RTPSess           rtp.Sender
 	PlaybackStream    device.AudioStream
 	Sender            *rtp.SwappableSender

--- a/internal/comms/receive.go
+++ b/internal/comms/receive.go
@@ -271,7 +271,7 @@ func (cfg *CommsConfig) playoutOneFrame(pc *PortChannel, rt *CommsRuntime, jitte
 		return
 	}
 
-	if jitter == nil {
+	if jitter == nil || pc.Decoder == nil {
 		zeroInt16(out)
 
 		return
@@ -279,14 +279,14 @@ func (cfg *CommsConfig) playoutOneFrame(pc *PortChannel, rt *CommsRuntime, jitte
 
 	payload, conceal := jitter.PopOrConceal(concealRecentWindow)
 	if payload != nil {
-		n, err := rt.Decoder.DecodeS16(payload, out)
+		n, err := pc.Decoder.DecodeS16(payload, out)
 		jitter.ReleasePayload(payload)
 
 		if err != nil {
 			cfg.Log.Debug().Err(err).Msg("comms: opus decode error; falling back to PLC")
 
 			// Try PLC into the same buffer.
-			n, err = rt.Decoder.DecodeS16(nil, out)
+			n, err = pc.Decoder.DecodeS16(nil, out)
 			if err != nil || n != len(out) {
 				zeroInt16(out)
 				pc.PlaybackUnderruns.Add(1)
@@ -321,7 +321,7 @@ func (cfg *CommsConfig) playoutOneFrame(pc *PortChannel, rt *CommsRuntime, jitte
 				cfg.Log.Trace().Int("consecutive_plc", pc.ConsecutivePLC).Msg("comms: jitter buffer gap → PLC")
 			}
 
-			n, err := rt.Decoder.DecodeS16(nil, out)
+			n, err := pc.Decoder.DecodeS16(nil, out)
 			if err != nil || n != len(out) {
 				zeroInt16(out)
 			}

--- a/internal/comms/receive.go
+++ b/internal/comms/receive.go
@@ -27,6 +27,20 @@ const maxConsecutivePLC = 10
 // is still willing to PLC.
 const concealRecentWindow = 200 * time.Millisecond
 
+const (
+	// receiveErrStreakThreshold is the number of consecutive ReadFromUDP
+	// failures after which receiveLoop starts backing off between attempts.
+	// The first errors stay instant so the socket-swap path (a single
+	// net.ErrClosed while UpdateMulticastEndpoint closes the old socket to
+	// unblock the read) never pays the backoff.
+	receiveErrStreakThreshold = 3
+
+	// receiveErrBackoff bounds the retry rate on a persistently failing
+	// socket to ~100 attempts/s instead of a busy spin that would pin a
+	// core on the embedded targets.
+	receiveErrBackoff = 10 * time.Millisecond
+)
+
 // zeroInt16 fills an int16 slice with zeros. Used by the playout callback to
 // emit silence into the malgo int16 playback buffer.
 func zeroInt16(out []int16) {
@@ -133,6 +147,12 @@ func (cfg *CommsConfig) receiveLoop(ctx context.Context, pc *PortChannel, rt *Co
 		cachedLocalIP    net.IP
 	)
 
+	// errStreak counts consecutive read failures. A handful of instant
+	// retries covers the legitimate transients (socket swap); beyond the
+	// threshold the loop backs off so a permanently dead socket cannot
+	// busy-spin this goroutine.
+	errStreak := 0
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -143,6 +163,8 @@ func (cfg *CommsConfig) receiveLoop(ctx context.Context, pc *PortChannel, rt *Co
 		n, src, err := pc.Receiver.ReadFromUDP(buf)
 		if err == nil {
 			pc.RxPkts.Add(1)
+
+			errStreak = 0
 		}
 
 		if err != nil {
@@ -160,6 +182,15 @@ func (cfg *CommsConfig) receiveLoop(ctx context.Context, pc *PortChannel, rt *Co
 					jitter.Reset()
 				} else {
 					cfg.Log.Error().Err(err).Msg("comms: recv error")
+				}
+
+				errStreak++
+				if errStreak >= receiveErrStreakThreshold {
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(receiveErrBackoff):
+					}
 				}
 
 				continue

--- a/internal/comms/receive_test.go
+++ b/internal/comms/receive_test.go
@@ -645,6 +645,7 @@ func TestRun_StopsReceiveLoopsWhenEventSourceCloses(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		before := reader.reads.Load()
+
 		time.Sleep(50 * time.Millisecond)
 
 		if reader.reads.Load() == before {

--- a/internal/comms/receive_test.go
+++ b/internal/comms/receive_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/openmanet/openmanetd/internal/comms/audiopool"
+	"github.com/openmanet/openmanetd/internal/comms/control"
 	"github.com/openmanet/openmanetd/internal/comms/rtp"
 	"github.com/openmanet/openmanetd/internal/comms/webaudio"
 )
@@ -573,6 +574,85 @@ func TestReceiveLoop_StampsLastRemoteRx(t *testing.T) {
 	if pc.RxGate.LastUnixNano() == 0 {
 		t.Error("expected rxGate to be marked after receiving a remote packet")
 	}
+}
+
+// ─── receiveLoop failure-path tests ───────────────────────────────────────────
+
+func TestReceiveLoop_BacksOffOnPersistentReadErrors(t *testing.T) {
+	// A permanently failing receiver (e.g. a socket closed by Start's
+	// teardown while the loop's context is still live) must not busy-spin.
+	// After a few consecutive errors the loop backs off between attempts.
+	reader := &fakeErrReader{err: net.ErrClosed}
+	pc := &PortChannel{
+		cfg:      McastPortConfig{Receive: true},
+		Receiver: rtp.NewSwappableReceiver(reader),
+	}
+	pc.ReceiveEnabled.Store(true)
+
+	rt := &CommsRuntime{Ports: []*PortChannel{pc}}
+	cfg := &CommsConfig{Log: zerolog.Nop()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		cfg.receiveLoop(ctx, pc, rt)
+	}()
+
+	// 100 ms of persistent errors must produce a bounded number of read
+	// attempts. With the consecutive-error threshold and backoff the loop
+	// makes on the order of a dozen attempts; a spinning loop makes
+	// hundreds of thousands.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("receiveLoop did not exit after cancel")
+	}
+
+	if n := reader.reads.Load(); n > 100 {
+		t.Fatalf("receiveLoop busy-spun on persistent read errors: %d reads in 100 ms", n)
+	}
+}
+
+func TestRun_StopsReceiveLoopsWhenEventSourceCloses(t *testing.T) {
+	// When the control source dies (e.g. PTT dongle unplugged), its events
+	// channel closes and Run returns; Start's defers then close every
+	// receiver while the manager's context is still live. The goroutines
+	// Run spawned must terminate with it instead of erroring against
+	// permanently closed sockets forever.
+	reader := &fakeErrReader{err: net.ErrClosed}
+	pc := &PortChannel{
+		cfg:      McastPortConfig{Receive: true},
+		Receiver: rtp.NewSwappableReceiver(reader),
+	}
+	pc.ReceiveEnabled.Store(true)
+
+	rt := &CommsRuntime{Ports: []*PortChannel{pc}}
+	cfg := &CommsConfig{Log: zerolog.Nop()}
+
+	src := &mockEventSource{ch: make(chan control.PTTEvent)}
+	close(src.ch)
+
+	cfg.Run(context.Background(), rt, src) // returns as soon as events closes
+
+	// After Run returns, the spawned receiveLoop must wind down: poll until
+	// the read count stops advancing.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		before := reader.reads.Load()
+		time.Sleep(50 * time.Millisecond)
+
+		if reader.reads.Load() == before {
+			return // loop has stopped
+		}
+	}
+
+	t.Fatal("receiveLoop still reading after Run returned; run-scoped cancellation missing")
 }
 
 // ─── receiveLoop socket-swap recovery tests ───────────────────────────────────

--- a/internal/comms/receive_test.go
+++ b/internal/comms/receive_test.go
@@ -23,9 +23,9 @@ func newReceiveRuntime() (*CommsRuntime, *PortChannel) {
 	pc.SendEnabled.Store(true)
 	pc.ReceiveEnabled.Store(true)
 	pc.PlaybackBuffer = make(chan []int16, 4)
+	pc.Decoder = &mockDecoder{returnN: int(rtp.FrameSamples)}
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{returnN: int(rtp.FrameSamples)},
+		Ports: []*PortChannel{pc},
 	}
 
 	return rt, pc
@@ -54,9 +54,45 @@ func driveOneFrame(cfg *CommsConfig, pc *PortChannel, rt *CommsRuntime, jb *rtp.
 	return out
 }
 
+func TestPlayoutOneFrame_UsesPerPortDecoder(t *testing.T) {
+	// Concurrent receive on multiple talk groups is a designed capability
+	// (any port can be receive-enabled at any time), and each playback
+	// callback runs on its own audio thread. Sharing one stateful Opus
+	// decoder across them is a CGO-level data race, so every port must own
+	// its own decoder instance.
+	cfg := &CommsConfig{Log: zerolog.Nop()}
+	rt := &CommsRuntime{}
+
+	makePort := func(fill int16) (*PortChannel, *rtp.JitterBuffer) {
+		pc := &PortChannel{cfg: McastPortConfig{Receive: true}}
+		pc.ReceiveEnabled.Store(true)
+		pc.Decoder = &mockDecoder{fillValue: fill, returnN: audiopool.FrameSize}
+
+		jb := rtp.NewJitterBuffer(1, 16)
+		jb.Push(0, []byte{1})
+
+		return pc, jb
+	}
+
+	pcA, jbA := makePort(11)
+	pcB, jbB := makePort(22)
+	rt.Ports = []*PortChannel{pcA, pcB}
+
+	outA := driveOneFrame(cfg, pcA, rt, jbA)
+	outB := driveOneFrame(cfg, pcB, rt, jbB)
+
+	if outA[0] != 11 {
+		t.Errorf("port A must decode through its own decoder; got sample %d, want 11", outA[0])
+	}
+
+	if outB[0] != 22 {
+		t.Errorf("port B must decode through its own decoder; got sample %d, want 22", outB[0])
+	}
+}
+
 func TestPlayoutOneFrame_DecodesPayload(t *testing.T) {
 	rt, pc := newReceiveRuntime()
-	rt.Decoder = &mockDecoder{fillValue: 1234, returnN: audiopool.FrameSize}
+	pc.Decoder = &mockDecoder{fillValue: 1234, returnN: audiopool.FrameSize}
 
 	jb := rtp.NewJitterBuffer(1, 16) // prebuffer=1: first push triggers start
 	jb.Push(0, []byte{0xAA, 0xBB})
@@ -80,7 +116,7 @@ func TestPlayoutOneFrame_PLCOnSkippedMissing(t *testing.T) {
 	// len >= maxDepth/2) so popOrConceal returns conceal=true → PLC must
 	// be invoked via the decoder with nil payload.
 	rt, pc := newReceiveRuntime()
-	rt.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
+	pc.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
 
 	jb := rtp.NewJitterBuffer(1, 4)
 
@@ -107,7 +143,7 @@ func TestPlayoutOneFrame_PLCOnConceal(t *testing.T) {
 	// The jitter buffer is then empty, so shouldConceal fires on the next
 	// playoutOneFrame call and the decoder is invoked with nil payload.
 	rt, pc := newReceiveRuntime()
-	rt.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
+	pc.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
 
 	jb := rtp.NewJitterBuffer(1, 16)
 
@@ -131,7 +167,7 @@ func TestPlayoutOneFrame_SilenceAfterMaxPLC(t *testing.T) {
 	// silence rather than calling the (now degraded) decoder PLC.
 	rt, pc := newReceiveRuntime()
 	dec := &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
-	rt.Decoder = dec
+	pc.Decoder = dec
 
 	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0})
@@ -221,7 +257,7 @@ func TestPlayoutOneFrame_NoUnderrunOnIdleStream(t *testing.T) {
 func TestPlayoutOneFrame_UnderrunOnDecoderError(t *testing.T) {
 	// Decoder returning an error AND PLC also failing → silence + underrun++.
 	rt, pc := newReceiveRuntime()
-	rt.Decoder = &mockDecoder{decodeErr: errors.New("bad decode")}
+	pc.Decoder = &mockDecoder{decodeErr: errors.New("bad decode")}
 
 	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0xAA, 0xBB})
@@ -242,7 +278,7 @@ func TestPlayoutOneFrame_DecoderErrorPLCFallback(t *testing.T) {
 	// Real decode fails but PLC succeeds → playoutOneFrame should emit the
 	// PLC samples, reset consecutivePLC, and NOT count an underrun.
 	rt, pc := newReceiveRuntime()
-	rt.Decoder = &mockDecoder{
+	pc.Decoder = &mockDecoder{
 		decodeErr: errors.New("bad decode"),
 		plcOK:     true,
 		returnN:   audiopool.FrameSize,
@@ -287,8 +323,7 @@ func TestReceiveLoop_DropsOwnPackets(t *testing.T) {
 	pc.ReceiveEnabled.Store(true)
 	pc.PlaybackBuffer = make(chan []int16, 16)
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{returnN: int(rtp.FrameSamples)},
+		Ports: []*PortChannel{pc},
 	}
 	s := localIP.String()
 	rt.LocalIP.Store(&s)
@@ -343,8 +378,7 @@ func TestReceiveLoop_DropsMalformedRTP(t *testing.T) {
 	pc.ReceiveEnabled.Store(true)
 	pc.PlaybackBuffer = make(chan []int16, 8)
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{},
+		Ports: []*PortChannel{pc},
 	}
 
 	cfg := &CommsConfig{Log: zerolog.Nop(), Loopback: true}
@@ -510,8 +544,7 @@ func TestReceiveLoop_StampsLastRemoteRx(t *testing.T) {
 	pc.ReceiveEnabled.Store(true)
 	pc.PlaybackBuffer = make(chan []int16, 32)
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{returnN: int(rtp.FrameSamples)},
+		Ports: []*PortChannel{pc},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -599,8 +632,7 @@ func TestReceiveLoop_SocketSwapResetsJitter(t *testing.T) {
 	pc.PlaybackBuffer = make(chan []int16, 64)
 
 	rt := &CommsRuntime{
-		Ports:   []*PortChannel{pc},
-		Decoder: &mockDecoder{returnN: int(rtp.FrameSamples)},
+		Ports: []*PortChannel{pc},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -774,7 +806,7 @@ func TestPlayoutOneFrame_ConsecutivePLCLimit(t *testing.T) {
 	// but all subsequent frames are missing. playoutOneFrame should emit
 	// exactly maxConsecutivePLC PLC frames followed by silence.
 	rt, pc := newReceiveRuntime()
-	rt.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
+	pc.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
 
 	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0})
@@ -803,7 +835,7 @@ func TestPlayoutOneFrame_ConsecutivePLCResets(t *testing.T) {
 	// After a burst of PLC, decoding a real frame should reset the
 	// consecutivePLC counter so a subsequent gap produces PLC again.
 	rt, pc := newReceiveRuntime()
-	rt.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
+	pc.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
 
 	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0})

--- a/internal/comms/receive_test.go
+++ b/internal/comms/receive_test.go
@@ -58,7 +58,7 @@ func TestPlayoutOneFrame_DecodesPayload(t *testing.T) {
 	rt, pc := newReceiveRuntime()
 	rt.Decoder = &mockDecoder{fillValue: 1234, returnN: audiopool.FrameSize}
 
-	jb := rtp.NewJitterBuffer(1, 10) // prebuffer=1: first push triggers start
+	jb := rtp.NewJitterBuffer(1, 16) // prebuffer=1: first push triggers start
 	jb.Push(0, []byte{0xAA, 0xBB})
 
 	cfg := &CommsConfig{Log: zerolog.Nop()}
@@ -109,7 +109,7 @@ func TestPlayoutOneFrame_PLCOnConceal(t *testing.T) {
 	rt, pc := newReceiveRuntime()
 	rt.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 
 	jb.Push(0, []byte{0})
 	jb.PopReady() // started=true, expected=1, lastPush set to now
@@ -133,7 +133,7 @@ func TestPlayoutOneFrame_SilenceAfterMaxPLC(t *testing.T) {
 	dec := &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
 	rt.Decoder = dec
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0})
 	jb.PopReady() // started=true, lastPush set
 
@@ -160,7 +160,7 @@ func TestPlayoutOneFrame_SilenceWhenBroadcasting(t *testing.T) {
 	rt, pc := newReceiveRuntime()
 	rt.Broadcasting.Store(true) // isBroadcasting will return true; pc.SendEnabled=true → suppress
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0xAA, 0xBB})
 
 	cfg := &CommsConfig{Log: zerolog.Nop()}
@@ -175,7 +175,7 @@ func TestPlayoutOneFrame_SilenceWhenReceiveDisabled(t *testing.T) {
 	rt, pc := newReceiveRuntime()
 	pc.ReceiveEnabled.Store(false)
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0xAA})
 
 	cfg := &CommsConfig{Log: zerolog.Nop()}
@@ -204,7 +204,7 @@ func TestPlayoutOneFrame_NoUnderrunOnIdleStream(t *testing.T) {
 	// Stream that has never started (no packets yet) should write silence
 	// without incrementing the underrun counter — silence != underrun.
 	rt, pc := newReceiveRuntime()
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 
 	cfg := &CommsConfig{Log: zerolog.Nop()}
 
@@ -223,7 +223,7 @@ func TestPlayoutOneFrame_UnderrunOnDecoderError(t *testing.T) {
 	rt, pc := newReceiveRuntime()
 	rt.Decoder = &mockDecoder{decodeErr: errors.New("bad decode")}
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0xAA, 0xBB})
 
 	cfg := &CommsConfig{Log: zerolog.Nop()}
@@ -249,7 +249,7 @@ func TestPlayoutOneFrame_DecoderErrorPLCFallback(t *testing.T) {
 		fillValue: 1234,
 	}
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0xAA, 0xBB})
 
 	cfg := &CommsConfig{Log: zerolog.Nop()}
@@ -679,7 +679,7 @@ func TestWebPlayoutLoop_ForwardsRawOpus(t *testing.T) {
 	})
 	rt.WebBridge = bridge
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0xAA, 0xBB, 0xCC})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -716,7 +716,7 @@ func TestWebPlayoutLoop_MultipleFrames(t *testing.T) {
 	})
 	rt.WebBridge = bridge
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	for i := 0; i < 5; i++ {
 		jb.Push(uint16(i), []byte{byte(i)})
 	}
@@ -751,7 +751,7 @@ func TestWebPlayoutLoop_DeliversWhileBroadcasting(t *testing.T) {
 	rt.WebBridge = bridge
 	rt.Broadcasting.Store(true)
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0x01})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -776,7 +776,7 @@ func TestPlayoutOneFrame_ConsecutivePLCLimit(t *testing.T) {
 	rt, pc := newReceiveRuntime()
 	rt.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0})
 	jb.PopReady() // started=true, expected=1, lastPush set
 
@@ -805,7 +805,7 @@ func TestPlayoutOneFrame_ConsecutivePLCResets(t *testing.T) {
 	rt, pc := newReceiveRuntime()
 	rt.Decoder = &mockDecoder{fillValue: 99, returnN: audiopool.FrameSize}
 
-	jb := rtp.NewJitterBuffer(1, 10)
+	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0})
 	jb.PopReady() // started=true, expected=1, lastPush set
 

--- a/internal/comms/rtp/jitter.go
+++ b/internal/comms/rtp/jitter.go
@@ -84,20 +84,20 @@ type JitterBuffer struct {
 	GapRuns11to20 atomic.Int64
 	GapRuns21to50 atomic.Int64
 	GapRunsOver50 atomic.Int64
-	count     int
-	prebuffer int
-	maxDepth  int
+	count         int
+	prebuffer     int
+	maxDepth      int
 	// depthMask is maxDepth-1, valid because maxDepth is a power of two.
 	// Slot indexing uses seq & depthMask so the mapping is continuous
 	// across the uint16 sequence wrap (and avoids a hardware divide on
 	// mipsle, where modulo by a non-power-of-two constant is a real DIV).
-	depthMask     int
-	mu            sync.Mutex
-	ssrc          uint32
-	expected      uint16
-	init          bool
-	started       bool
-	haveSSRC      bool
+	depthMask int
+	mu        sync.Mutex
+	ssrc      uint32
+	expected  uint16
+	init      bool
+	started   bool
+	haveSSRC  bool
 	// inGap is true when the consumer is currently walking through a
 	// contiguous missing-sequence run. Cleared on every successful pop
 	// and on reset. Used to ensure each run is bucketed exactly once.

--- a/internal/comms/rtp/jitter.go
+++ b/internal/comms/rtp/jitter.go
@@ -13,7 +13,14 @@ const (
 	// arrival jitter on the mesh. 100 ms tolerates roughly one full packet
 	// of late arrival before the buffer empties and playout falls into PLC.
 	PrebufferPackets = 5
-	MaxDepth         = 24
+
+	// MaxDepth is the jitter ring capacity in frames. It MUST be a power of
+	// two: slots are indexed by seq & (maxDepth-1), and only a power-of-two
+	// depth keeps the seq→slot mapping continuous across the uint16 sequence
+	// wrap (65536 % maxDepth == 0). A non-power-of-two depth makes in-window
+	// frames collide at the wrap and evict each other, which surfaces as an
+	// unattributable PLC glitch every ~22 minutes of continuous talk.
+	MaxDepth = 32
 
 	// MaxOpusPayloadSize is the RFC 6716 §3.2.1 maximum encoded frame size.
 	// Payload pool buffers are sized to this capacity to eliminate per-packet
@@ -43,7 +50,8 @@ type jitterSlot struct {
 // previous talker's frozen sequence cursor.
 //
 // Internally, frames are stored in a fixed-size circular array indexed by
-// (seq % maxDepth), eliminating all map allocations on the hot path.
+// (seq & (maxDepth-1)), eliminating all map allocations on the hot path.
+// maxDepth must be a power of two so the mapping survives uint16 wrap.
 //
 // notifyCh is the optional edge-triggered "frame available" wakeup used by
 // consumers that prefer push-driven scheduling over a polling ticker (see
@@ -76,9 +84,14 @@ type JitterBuffer struct {
 	GapRuns11to20 atomic.Int64
 	GapRuns21to50 atomic.Int64
 	GapRunsOver50 atomic.Int64
-	count         int
-	prebuffer     int
-	maxDepth      int
+	count     int
+	prebuffer int
+	maxDepth  int
+	// depthMask is maxDepth-1, valid because maxDepth is a power of two.
+	// Slot indexing uses seq & depthMask so the mapping is continuous
+	// across the uint16 sequence wrap (and avoids a hardware divide on
+	// mipsle, where modulo by a non-power-of-two constant is a real DIV).
+	depthMask     int
 	mu            sync.Mutex
 	ssrc          uint32
 	expected      uint16
@@ -91,10 +104,19 @@ type JitterBuffer struct {
 	inGap bool
 }
 
+// NewJitterBuffer constructs a jitter buffer. maxDepth must be a power of
+// two no larger than MaxDepth; anything else is an init-time programmer
+// error and panics — a non-power-of-two depth would silently corrupt the
+// seq→slot mapping at every uint16 sequence wrap.
 func NewJitterBuffer(prebuffer, maxDepth int) *JitterBuffer {
+	if maxDepth <= 0 || maxDepth > MaxDepth || maxDepth&(maxDepth-1) != 0 {
+		panic("rtp: jitter buffer maxDepth must be a power of two in [1, MaxDepth]")
+	}
+
 	jb := &JitterBuffer{
 		prebuffer: prebuffer,
 		maxDepth:  maxDepth,
+		depthMask: maxDepth - 1,
 	}
 
 	jb.payloadPool.New = func() any {
@@ -206,6 +228,15 @@ func (jb *JitterBuffer) EnableNotify() <-chan struct{} {
 
 // pushLocked is the internal push implementation; caller must hold jb.mu.
 func (jb *JitterBuffer) pushLocked(seq uint16, payload []byte) bool {
+	// Reject payloads larger than the pool buffer capacity. The receive path
+	// reads datagrams bigger than MaxOpusPayloadSize (its read buffer is MTU
+	// sized), so a malformed or hostile sender could otherwise drive the
+	// reslice below out of bounds. A conforming sender can never hit this:
+	// RFC 6716 caps a single Opus frame at MaxOpusPayloadSize bytes.
+	if len(payload) > MaxOpusPayloadSize {
+		return false
+	}
+
 	// Idle-reset safety net: if a long gap has elapsed since the last push,
 	// treat the next packet as the start of a fresh stream regardless of
 	// sequence number. Catches edge cases the SSRC check cannot, e.g. a sender
@@ -226,7 +257,7 @@ func (jb *JitterBuffer) pushLocked(seq uint16, payload []byte) bool {
 		return false
 	}
 
-	idx := int(seq) % jb.maxDepth
+	idx := int(seq) & jb.depthMask
 	slot := &jb.slots[idx]
 
 	// Duplicate: same seq already stored in this slot.
@@ -282,7 +313,7 @@ func (jb *JitterBuffer) popReadyLocked() (payload []byte, ready bool, skippedMis
 		jb.started = true
 	}
 
-	idx := int(jb.expected) % jb.maxDepth
+	idx := int(jb.expected) & jb.depthMask
 	slot := &jb.slots[idx]
 
 	if slot.valid && slot.seq == jb.expected {
@@ -342,7 +373,7 @@ func (jb *JitterBuffer) AdvancePast() {
 
 // advancePastLocked is the lock-free internal implementation.
 func (jb *JitterBuffer) advancePastLocked() {
-	idx := int(jb.expected) % jb.maxDepth
+	idx := int(jb.expected) & jb.depthMask
 	slot := &jb.slots[idx]
 
 	if slot.valid && slot.seq == jb.expected {
@@ -426,7 +457,7 @@ func (jb *JitterBuffer) resetLocked() {
 func (jb *JitterBuffer) measureGapRunLocked() int {
 	for k := 0; k < jb.maxDepth; k++ {
 		seq := jb.expected + uint16(k)
-		idx := int(seq) % jb.maxDepth
+		idx := int(seq) & jb.depthMask
 		slot := &jb.slots[idx]
 
 		if slot.valid && slot.seq == seq {

--- a/internal/comms/rtp/jitter_test.go
+++ b/internal/comms/rtp/jitter_test.go
@@ -34,8 +34,82 @@ func TestSeqLess_WrapAround(t *testing.T) {
 	}
 }
 
+func TestJitterBuffer_PushOversizedPayload(t *testing.T) {
+	jb := NewJitterBuffer(1, MaxDepth)
+
+	// receiveLoop reads into a 1500-byte buffer, so a hostile or malformed
+	// sender can deliver an RTP payload larger than the pool's
+	// MaxOpusPayloadSize capacity. Push must reject it, not panic.
+	oversized := make([]byte, MaxOpusPayloadSize+125)
+	if ok := jb.Push(0, oversized); ok {
+		t.Fatal("oversized payload must be rejected")
+	}
+
+	// The buffer must remain fully usable afterwards.
+	if ok := jb.Push(1, []byte{42}); !ok {
+		t.Fatal("push after oversized rejection must succeed")
+	}
+
+	payload, ready, _ := jb.PopReady()
+	if !ready || payload[0] != 42 {
+		t.Fatalf("expected seq=1 payload after rejection, got ready=%v payload=%v", ready, payload)
+	}
+}
+
+func TestJitterBuffer_SeqWrapContinuity(t *testing.T) {
+	jb := NewJitterBuffer(1, MaxDepth)
+
+	// A window of 24 in-flight frames straddling the uint16 sequence wrap.
+	// The seq→slot mapping must be continuous across the wrap: if maxDepth
+	// does not divide 65536, in-window frames collide and evict each other,
+	// surfacing as periodic PLC gaps roughly every 22 minutes of talk.
+	seqs := make([]uint16, 0, 24)
+	for i := range 24 {
+		seqs = append(seqs, uint16(65524+i)) // 65524..65535, then 0..11
+	}
+
+	for _, s := range seqs {
+		if !jb.Push(s, []byte{byte(s)}) {
+			t.Fatalf("push seq=%d must succeed", s)
+		}
+	}
+
+	for _, s := range seqs {
+		payload, ready, skipped := jb.PopReady()
+		if !ready {
+			t.Fatalf("seq=%d: expected in-order pop, got ready=false skipped=%v", s, skipped)
+		}
+
+		if payload[0] != byte(s) {
+			t.Fatalf("seq=%d: wrong payload byte %d", s, payload[0])
+		}
+
+		jb.ReleasePayload(payload)
+	}
+}
+
+func TestNewJitterBuffer_RejectsNonPowerOfTwoDepth(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for non-power-of-two depth")
+		}
+	}()
+
+	NewJitterBuffer(1, 10)
+}
+
+func TestNewJitterBuffer_RejectsDepthBeyondSlots(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for depth larger than the slot array")
+		}
+	}()
+
+	NewJitterBuffer(1, MaxDepth*2)
+}
+
 func TestJitterBuffer_InOrderDelivery(t *testing.T) {
-	jb := NewJitterBuffer(1, 10) // prebuffer=1 so first push triggers start
+	jb := NewJitterBuffer(1, 16) // prebuffer=1 so first push triggers start
 
 	jb.Push(10, []byte{1, 2, 3})
 
@@ -54,7 +128,7 @@ func TestJitterBuffer_InOrderDelivery(t *testing.T) {
 }
 
 func TestJitterBuffer_Prebuffer(t *testing.T) {
-	jb := NewJitterBuffer(3, 10)
+	jb := NewJitterBuffer(3, 16)
 
 	// Push only 2 packets — not enough to start.
 	jb.Push(0, []byte{0})
@@ -75,7 +149,7 @@ func TestJitterBuffer_Prebuffer(t *testing.T) {
 }
 
 func TestJitterBuffer_StalePacketRejected(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	jb.Push(5, []byte{5})
 
@@ -87,7 +161,7 @@ func TestJitterBuffer_StalePacketRejected(t *testing.T) {
 }
 
 func TestJitterBuffer_DuplicateRejected(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	if !jb.Push(10, []byte{10}) {
 		t.Fatal("first push should succeed")
@@ -100,7 +174,7 @@ func TestJitterBuffer_DuplicateRejected(t *testing.T) {
 
 func TestJitterBuffer_OutOfOrderDelivery(t *testing.T) {
 	// prebuffer=1 so a single push satisfies the threshold.
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	// Push seq=0 first — this sets expected=0 and satisfies the prebuffer.
 	jb.Push(0, []byte{0})
@@ -164,7 +238,7 @@ func TestJitterBuffer_SkipMissingWhenOverflow(t *testing.T) {
 }
 
 func TestJitterBuffer_ShouldConceal(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	// Not started yet — should NOT conceal.
 	if jb.ShouldConceal(100 * time.Millisecond) {
@@ -181,7 +255,7 @@ func TestJitterBuffer_ShouldConceal(t *testing.T) {
 }
 
 func TestJitterBuffer_AdvancePast(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	jb.Push(0, []byte{0})
 	jb.PopReady() // expected=1 now
@@ -202,7 +276,7 @@ func TestJitterBuffer_AdvancePast(t *testing.T) {
 }
 
 func TestJitterBuffer_WrapAroundSequence(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	// Start just below wrap point.
 	jb.Push(0xFFFE, []byte{0xFE})
@@ -226,7 +300,7 @@ func TestJitterBuffer_WrapAroundSequence(t *testing.T) {
 // ─── popOrConceal tests ──────────────────────────────────────────────────────
 
 func TestPopOrConceal_ReturnsReadyFrame(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0xAA})
 
 	payload, conceal := jb.PopOrConceal(100 * time.Millisecond)
@@ -259,7 +333,7 @@ func TestPopOrConceal_ConcealOnSkippedGap(t *testing.T) {
 }
 
 func TestPopOrConceal_ConcealOnEmptyActiveStream(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	jb.Push(0, []byte{0})
 	jb.PopOrConceal(100 * time.Millisecond) // started=true, lastPush ~now
@@ -276,7 +350,7 @@ func TestPopOrConceal_ConcealOnEmptyActiveStream(t *testing.T) {
 }
 
 func TestPopOrConceal_NoConcealWhenStale(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	jb.Push(0, []byte{0})
 	jb.PopOrConceal(100 * time.Millisecond)
@@ -297,7 +371,7 @@ func TestPopOrConceal_NoConcealWhenStale(t *testing.T) {
 }
 
 func TestPopOrConceal_NoConcealBeforeStart(t *testing.T) {
-	jb := NewJitterBuffer(3, 10)
+	jb := NewJitterBuffer(3, 16)
 
 	// Only push 1 packet, need 3 for prebuffer.
 	jb.Push(0, []byte{0})
@@ -311,7 +385,7 @@ func TestPopOrConceal_NoConcealBeforeStart(t *testing.T) {
 // ─── Ring buffer integrity tests ─────────────────────────────────────────────
 
 func TestJitterBuffer_PushCopiesPayload(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	input := []byte{1, 2, 3}
 	jb.Push(0, input)
@@ -386,7 +460,7 @@ func TestJitterBuffer_FullBufferRejectsNewSequence(t *testing.T) {
 // TestJitterBuffer_Reset_ClearsState verifies that reset() zeros all internal
 // state so the jitter buffer behaves as if freshly constructed.
 func TestJitterBuffer_Reset_ClearsState(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	// Advance to started state.
 	jb.Push(0, []byte{0})
@@ -432,7 +506,7 @@ func TestJitterBuffer_Reset_ClearsState(t *testing.T) {
 // in the "past half" of the previous talker's frozen cursor must NOT be
 // rejected. The jitter buffer must detect the SSRC change and reset.
 func TestJitterBuffer_SSRCChangeResets(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	const (
 		ssrcA = uint32(0x11111111)
@@ -493,7 +567,7 @@ func TestJitterBuffer_SSRCChangeResets(t *testing.T) {
 // TestJitterBuffer_SSRCChange_NoCallbackOnSameSSRC verifies that a stream of
 // packets all sharing the same SSRC never triggers the SSRC-change path.
 func TestJitterBuffer_SSRCChange_NoCallbackOnSameSSRC(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	called := false
 	cb := func(_, _ uint32) { called = true }
@@ -516,7 +590,7 @@ func TestJitterBuffer_SSRCChange_NoCallbackOnSameSSRC(t *testing.T) {
 // must still be dropped (otherwise we'd accept duplicates and out-of-window
 // reorderings as fresh streams).
 func TestJitterBuffer_SameSSRCStalePacketStillDropped(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	jb.PushWithSSRC(1, 100, []byte{100}, nil)
 	jb.PopReady() // expected = 101
@@ -531,7 +605,7 @@ func TestJitterBuffer_SameSSRCStalePacketStillDropped(t *testing.T) {
 // the start of a fresh stream, even with the same SSRC.
 func TestJitterBuffer_IdleTimeoutResets(t *testing.T) {
 	fakeNow := time.Unix(0, 0)
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 	jb.now = func() time.Time { return fakeNow }
 
 	// First push at t=0, drain it.
@@ -564,7 +638,7 @@ func TestJitterBuffer_IdleTimeoutResets(t *testing.T) {
 // within the idle window do not trigger a reset.
 func TestJitterBuffer_IdleTimeout_NoResetWithinWindow(t *testing.T) {
 	fakeNow := time.Unix(0, 0)
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 	jb.now = func() time.Time { return fakeNow }
 
 	jb.PushWithSSRC(1, 1000, []byte{0xAA}, nil)
@@ -586,7 +660,7 @@ func TestJitterBuffer_IdleTimeout_NoResetWithinWindow(t *testing.T) {
 // TestJitterBuffer_Reset_PrebufferRestartsAfterReset verifies that after reset
 // the prebuffer threshold must be satisfied again before popReady returns frames.
 func TestJitterBuffer_Reset_PrebufferRestartsAfterReset(t *testing.T) {
-	jb := NewJitterBuffer(3, 10) // need 3 pushes before started
+	jb := NewJitterBuffer(3, 16) // need 3 pushes before started
 
 	// Satisfy prebuffer and advance to started.
 	for i := uint16(0); i < 3; i++ {
@@ -622,7 +696,7 @@ func TestJitterBuffer_Reset_PrebufferRestartsAfterReset(t *testing.T) {
 // installed by EnableNotify: a successful push must wake any consumer that
 // has parked on the channel within a single signal interval.
 func TestJitterBuffer_NotifyOnPush(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	notify := jb.EnableNotify()
 
@@ -648,7 +722,7 @@ func TestJitterBuffer_NotifyOnPush(t *testing.T) {
 // signals into one, and the consumer is responsible for draining all
 // available frames per wake.
 func TestJitterBuffer_NotifyCoalescesBurst(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	notify := jb.EnableNotify()
 
@@ -682,7 +756,7 @@ func TestJitterBuffer_NotifyCoalescesBurst(t *testing.T) {
 // never call EnableNotify pay no signaling cost: pushes succeed silently and
 // no goroutine ever wakes from a notify channel.
 func TestJitterBuffer_NotifyDisabledByDefault(t *testing.T) {
-	jb := NewJitterBuffer(1, 10)
+	jb := NewJitterBuffer(1, 16)
 
 	if jb.notifyCh != nil {
 		t.Fatal("notifyCh should be nil before EnableNotify is called")
@@ -702,7 +776,7 @@ func TestJitterBuffer_NotifyDisabledByDefault(t *testing.T) {
 // event, not once per skipped frame, and that a successful pop
 // terminates a run so the next gap is counted independently.
 func TestJitterBuffer_GapHistogram(t *testing.T) {
-	maxDepth := 24
+	maxDepth := 32
 	jb := NewJitterBuffer(1, maxDepth)
 
 	// Initialize expected=0, prebuffer satisfied.
@@ -713,17 +787,16 @@ func TestJitterBuffer_GapHistogram(t *testing.T) {
 	}
 	// expected is now 1.
 
-	// Craft a single 3-frame gap at 1..3, with 4..13 present (10 frames,
-	// ≥ maxDepth/2 = 12... not quite. Push enough to trip the skip.)
-	// We need jb.count >= 12 to enter the skip branch. Push seqs
-	// 4..15 (12 packets) leaving 1..3 missing.
-	for s := uint16(4); s <= 15; s++ {
+	// Craft a single 3-frame gap at 1..3. We need jb.count >= maxDepth/2 = 16
+	// to enter the skip branch. Push seqs 4..19 (16 packets) leaving 1..3
+	// missing.
+	for s := uint16(4); s <= 19; s++ {
 		if !jb.Push(s, []byte{byte(s)}) {
 			t.Fatalf("push seq=%d must succeed", s)
 		}
 	}
 
-	// First PopReady: expected=1, slot empty, count=12 ≥ 12 → skip.
+	// First PopReady: expected=1, slot empty, count=16 ≥ 16 → skip.
 	// measureGapRunLocked should return 3 (seqs 1,2,3 missing before 4).
 	if _, _, skipped := jb.PopReady(); !skipped {
 		t.Fatal("expected skipped=true at head of gap")
@@ -755,8 +828,8 @@ func TestJitterBuffer_GapHistogram(t *testing.T) {
 		t.Fatal("expected ready=true at seq=4")
 	}
 
-	// Drain 5..15 cleanly. No new gap runs should be counted.
-	for i := 0; i < 11; i++ {
+	// Drain 5..19 cleanly. No new gap runs should be counted.
+	for i := 0; i < 15; i++ {
 		if _, ready, _ := jb.PopReady(); !ready {
 			t.Fatalf("drain iter %d: expected ready=true", i)
 		}
@@ -774,7 +847,7 @@ func TestJitterBuffer_GapHistogram(t *testing.T) {
 // TestJitterBuffer_GapHistogram_SingleFrame verifies that a 1-frame
 // gap lands in the GapRuns1 bucket.
 func TestJitterBuffer_GapHistogram_SingleFrame(t *testing.T) {
-	maxDepth := 24
+	maxDepth := 32
 	jb := NewJitterBuffer(1, maxDepth)
 
 	jb.Push(0, []byte{0})
@@ -784,9 +857,9 @@ func TestJitterBuffer_GapHistogram_SingleFrame(t *testing.T) {
 	}
 	// expected=1.
 
-	// Single missing frame at seq=1, followed by 2..13 (12 packets)
-	// so count=12 meets skip threshold.
-	for s := uint16(2); s <= 13; s++ {
+	// Single missing frame at seq=1, followed by 2..17 (16 packets)
+	// so count=16 meets the maxDepth/2 skip threshold.
+	for s := uint16(2); s <= 17; s++ {
 		jb.Push(s, []byte{byte(s)})
 	}
 

--- a/internal/comms/transmit.go
+++ b/internal/comms/transmit.go
@@ -216,7 +216,16 @@ func (cfg *CommsConfig) endTransmission(rt *CommsRuntime) {
 // Receive-capable port plus a single halfDuplexDecayLoop that clears the
 // cached RemoteRxActive flag when every gate has gone quiet, then blocks
 // dispatching PTT events until ctx is canceled.
-func (cfg *CommsConfig) Run(ctx context.Context, rt *CommsRuntime, src control.EventSource) {
+func (cfg *CommsConfig) Run(parentCtx context.Context, rt *CommsRuntime, src control.EventSource) {
+	// Run owns the loops it spawns: derive a context cancelled when Run
+	// returns for any reason — parent cancellation or the event source
+	// closing its channel (e.g. the PTT device dying). Without this,
+	// Start's deferred teardown closes every receiver while the manager's
+	// context is still live and the receive loops retry against
+	// permanently dead sockets until Disable is called.
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
 	for _, pc := range rt.Ports {
 		if pc.Receiver != nil {
 			go cfg.receiveLoop(ctx, pc, rt)
@@ -232,7 +241,13 @@ func (cfg *CommsConfig) Run(ctx context.Context, rt *CommsRuntime, src control.E
 	events := src.Events(ctx)
 
 	if aux, ok := src.(control.AuxEventSource); ok && cfg.AuxHandler != nil {
-		go cfg.runAuxPump(ctx, aux)
+		// The aux pump deliberately runs on the parent context, not the
+		// Run-scoped one: it must drain aux events still queued when the
+		// PTT channel closes, and it has its own natural termination — the
+		// control source closes its aux channel when it dies, and Disable
+		// cancels the parent. Run-scoped cancellation would cut the drain
+		// short (pinned by TestRun_AuxEvents_DispatchedToHandler).
+		go cfg.runAuxPump(parentCtx, aux)
 	}
 
 	// In-run audio recovery: when hardware audio failed at startup (or the

--- a/internal/comms/transmit.go
+++ b/internal/comms/transmit.go
@@ -217,7 +217,7 @@ func (cfg *CommsConfig) endTransmission(rt *CommsRuntime) {
 // cached RemoteRxActive flag when every gate has gone quiet, then blocks
 // dispatching PTT events until ctx is canceled.
 func (cfg *CommsConfig) Run(parentCtx context.Context, rt *CommsRuntime, src control.EventSource) {
-	// Run owns the loops it spawns: derive a context cancelled when Run
+	// Run owns the loops it spawns: derive a context canceled when Run
 	// returns for any reason — parent cancellation or the event source
 	// closing its channel (e.g. the PTT device dying). Without this,
 	// Start's deferred teardown closes every receiver while the manager's

--- a/internal/comms/transmit_test.go
+++ b/internal/comms/transmit_test.go
@@ -32,7 +32,6 @@ func newTestRuntime(stream BroadcastCapture) *CommsRuntime {
 		Ports:           []*PortChannel{pc},
 		BeepBufferStart: []int16{100, 200},
 		BeepBufferStop:  []int16{300, 400},
-		Decoder:         &mockDecoder{},
 	}
 	rt.SetBroadcast(stream)
 
@@ -656,7 +655,6 @@ func TestEndTransmission_QueuesStopBeepToAllPorts(t *testing.T) {
 		Ports:           []*PortChannel{pc0, pc1},
 		BeepBufferStart: []int16{100, 200},
 		BeepBufferStop:  []int16{300, 400},
-		Decoder:         &mockDecoder{},
 	}
 	rt.SetBroadcast(&mockStream{})
 


### PR DESCRIPTION
## Summary

Four correctness-grade defects found by the `internal/comms` performance review, each reproduced by a failing test before the fix (TDD red-green):

1. **Oversized-payload panic (remote-triggerable).** `pushLocked` resliced a pooled 1275-byte buffer to `len(payload)` with no guard while the receive path reads MTU-sized datagrams — any RTP-framed packet with a payload > 1275 B crashed the daemon. Now rejected before touching the pool (counted in `rx_push_rejected`). A conforming Opus sender can never hit this: RFC 6716 caps a single frame at 1275 bytes.

2. **Jitter-ring corruption at sequence wrap.** Slots were indexed `seq % 24`, and 65536 % 24 ≠ 0, so the seq→slot mapping broke at every uint16 wrap: in-window frames evicted each other as "stale", surfacing as an unattributable PLC glitch ~every 22 min of continuous talk per sender. `MaxDepth` is now 32 with mask indexing (`seq & (maxDepth-1)`), the constructor rejects non-power-of-two depths, and a wrap-continuity test pins the behavior. Bonus: removes a per-packet hardware divide on mipsle.

3. **Shared Opus decoder across concurrent playback threads.** All ports' malgo playback callbacks decoded through one unlocked `CommsRuntime.Decoder`. RX can be enabled on any port at any time by design, so two RT threads could enter `opus_decode` on the same state — a C-level data race — and even serialized, interleaved streams corrupt each other's prediction state. Each receive-capable port now owns a private decoder (~27 KB each; the decoder moves to `PortChannel`).

4. **100% CPU spin after control-source death.** When the PTT device dies, `Run` returns and `Start`'s defers close every receiver — but the manager context stayed live, so all receive loops spun on `net.ErrClosed` forever (reproduced: 2.4M reads in 100 ms). `Run` now derives a context cancelled when it returns, and `receiveLoop` backs off 10 ms after 3 consecutive read errors. The single-error socket-swap path stays instant (guarded by the existing swap-recovery test), and the aux pump deliberately keeps the parent context so it drains queued events (pinned by existing test).

## Behavior preservation

Each fix was adversarially traced before implementation: the payload guard can only reject packets that would currently panic; the decoder had exactly one consumer (`playoutOneFrame`); playout latency is prebuffer-driven so depth 32 only reduces overflow drops; and post-`Run`-exit the runtime was already fully torn down, so cancellation only stops orphaned goroutines. One deliberate exception is documented in-code: the aux pump stays on the parent context to preserve its drain semantics.

## Testing

- New tests: oversized-payload rejection, seq-wrap continuity, constructor depth validation, per-port decoder wiring + playout routing, persistent-read-error backoff, run-scoped loop termination — every one watched fail before the fix
- `make lint-go`: 0 issues · `make test`: pass · `make test-race`: pass · `make integration-test`: pass
- `docs/instrumentation-snapshot.md` updated in-changeset (`rx_push_rejected`, `jitter.gap_runs_21_50`) per the instrumentation rule; test-only jitter depths migrated to powers of two
