### PR TITLE
perf(comms): zero-allocation RTP send and receive hot paths

### DIFF
--- a/internal/comms/bench_test.go
+++ b/internal/comms/bench_test.go
@@ -248,11 +248,14 @@ func BenchmarkParseIncomingRTP(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	// Mirror the receiveLoop hot path: one Packet reused across parses.
+	var pkt pionrtp.Packet
+
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for b.Loop() {
-		if _, err := rtp.ParseIncoming(raw); err != nil {
+		if err := rtp.ParseIncomingInto(raw, &pkt); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/comms/bench_test.go
+++ b/internal/comms/bench_test.go
@@ -2,6 +2,7 @@ package comms
 
 import (
 	"math"
+	"net"
 	"testing"
 	"time"
 
@@ -252,6 +253,45 @@ func BenchmarkParseIncomingRTP(b *testing.B) {
 
 	for b.Loop() {
 		if _, err := rtp.ParseIncoming(raw); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkReceiverRead measures the per-packet cost of the receive socket
+// read exactly as receiveLoop performs it: through the PacketReader interface
+// with a SwappableReceiver wrapping a real *net.UDPConn on loopback. The
+// sender write inside the loop is the same single sendto(2) both before and
+// after any read-path change, so alloc deltas isolate the read side.
+func BenchmarkReceiverRead(b *testing.B) {
+	recvConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Cleanup(func() { _ = recvConn.Close() })
+
+	sendConn, err := net.DialUDP("udp4", nil, recvConn.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Cleanup(func() { _ = sendConn.Close() })
+
+	var r rtp.PacketReader = rtp.NewSwappableReceiver(recvConn)
+
+	buf := make([]byte, 1500)
+	msg := make([]byte, 160) // typical Opus 20ms frame + RTP header
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if _, err := sendConn.Write(msg); err != nil {
+			b.Fatal(err)
+		}
+
+		if _, _, err := r.ReadFromUDP(buf); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/comms/bench_test.go
+++ b/internal/comms/bench_test.go
@@ -294,7 +294,7 @@ func BenchmarkReceiverRead(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		if _, _, err := r.ReadFromUDP(buf); err != nil {
+		if _, _, err := r.ReadFromUDPAddrPort(buf); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/comms/comms_test.go
+++ b/internal/comms/comms_test.go
@@ -3,6 +3,7 @@ package comms
 import (
 	"context"
 	"net"
+	"net/netip"
 	"os"
 	"testing"
 	"time"
@@ -76,7 +77,7 @@ func TestReceiveLoop_IngestsPackets(t *testing.T) {
 
 	for i := 0; i < rtp.PrebufferPackets+2; i++ {
 		raw := makeRTPBytes(t, uint16(i))
-		pkts = append(pkts, mockPacket{data: raw, src: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4)}})
+		pkts = append(pkts, mockPacket{data: raw, src: netip.MustParseAddrPort("1.2.3.4:5004")})
 	}
 
 	reader := newMockReader(pkts...)

--- a/internal/comms/integration_test.go
+++ b/internal/comms/integration_test.go
@@ -5,6 +5,7 @@ package comms
 import (
 	"context"
 	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -135,7 +136,7 @@ func drainConcealmentFrames(cfg *CommsConfig, pc *PortChannel, rt *CommsRuntime)
 // pushPackets enqueues raw datagrams onto the mockReader so the next
 // ReadFromUDP calls return them. Safe to call concurrently with receiveLoop.
 func pushPackets(reader *mockReader, raws ...[]byte) {
-	src := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4)}
+	src := netip.MustParseAddrPort("1.2.3.4:5004")
 
 	reader.mu.Lock()
 	defer reader.mu.Unlock()

--- a/internal/comms/integration_test.go
+++ b/internal/comms/integration_test.go
@@ -4,7 +4,6 @@ package comms
 
 import (
 	"context"
-	"net"
 	"net/netip"
 	"testing"
 	"time"

--- a/internal/comms/mocks_test.go
+++ b/internal/comms/mocks_test.go
@@ -3,7 +3,7 @@ package comms
 import (
 	"context"
 	"errors"
-	"net"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 
@@ -166,7 +166,7 @@ type trackingReader struct {
 	mu     sync.Mutex
 }
 
-func (r *trackingReader) ReadFromUDP(_ []byte) (int, *net.UDPAddr, error) {
+func (r *trackingReader) ReadFromUDPAddrPort(_ []byte) (int, netip.AddrPort, error) {
 	// Block forever until closed – tests drive this via Close().
 	select {} //nolint:staticcheck
 }
@@ -183,7 +183,7 @@ func (r *trackingReader) Close() error {
 // ─── mockPacket / mockReader ──────────────────────────────────────────────────
 
 type mockPacket struct {
-	src  *net.UDPAddr
+	src  netip.AddrPort
 	data []byte
 }
 
@@ -203,7 +203,7 @@ func newMockReader(pkts ...mockPacket) *mockReader {
 	}
 }
 
-func (m *mockReader) ReadFromUDP(b []byte) (int, *net.UDPAddr, error) {
+func (m *mockReader) ReadFromUDPAddrPort(b []byte) (int, netip.AddrPort, error) {
 	for {
 		m.mu.Lock()
 
@@ -220,7 +220,7 @@ func (m *mockReader) ReadFromUDP(b []byte) (int, *net.UDPAddr, error) {
 
 		select {
 		case <-m.closed:
-			return 0, nil, errors.New("reader closed")
+			return 0, netip.AddrPort{}, errors.New("reader closed")
 		default:
 		}
 	}
@@ -242,18 +242,18 @@ func (m *mockReader) remaining() int {
 
 // ─── fakeErrReader ───────────────────────────────────────────────────────────
 
-// fakeErrReader is a PacketReader whose ReadFromUDP always fails with err.
-// reads counts attempts so tests can assert receiveLoop backs off instead of
+// fakeErrReader is a PacketReader whose reads always fail with err. reads
+// counts attempts so tests can assert receiveLoop backs off instead of
 // busy-spinning on a permanently failing socket.
 type fakeErrReader struct {
 	err   error
 	reads atomic.Int64
 }
 
-func (f *fakeErrReader) ReadFromUDP(_ []byte) (int, *net.UDPAddr, error) {
+func (f *fakeErrReader) ReadFromUDPAddrPort(_ []byte) (int, netip.AddrPort, error) {
 	f.reads.Add(1)
 
-	return 0, nil, f.err
+	return 0, netip.AddrPort{}, f.err
 }
 
 func (f *fakeErrReader) Close() error { return nil }

--- a/internal/comms/multiport_test.go
+++ b/internal/comms/multiport_test.go
@@ -3,7 +3,7 @@ package comms
 import (
 	"context"
 	"errors"
-	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -292,7 +292,7 @@ func TestReceiveLoop_SkipsDeliveryWhenReceiveDisabled(t *testing.T) {
 
 	// Pre-load one valid RTP packet.
 	raw := makeRTPBytes(t, 0)
-	src := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 5004}
+	src := netip.MustParseAddrPort("1.2.3.4:5004")
 	reader := newMockReader(
 		mockPacket{data: raw, src: src},
 	)

--- a/internal/comms/receive.go
+++ b/internal/comms/receive.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/netip"
 	"time"
 
 	pionrtp "github.com/pion/rtp"
@@ -140,13 +141,14 @@ func (cfg *CommsConfig) receiveLoop(ctx context.Context, pc *PortChannel, rt *Co
 		go cfg.webPlayoutLoop(ctx, pc, jitter, rt)
 	}
 
-	// cachedLocalIP caches the parsed form of rt.LocalIP so that the loopback
-	// filter can use a byte-level net.IP.Equal comparison instead of calling
-	// src.IP.String() (which allocates) on every received packet. The cached
-	// value is refreshed only when the string changes (i.e. on endpoint swap).
+	// cachedLocalIP caches the parsed form of rt.LocalIP so the loopback
+	// filter is a value comparison on every received packet. The cached
+	// value is refreshed only when the string changes (i.e. on endpoint
+	// swap). Stored unmapped so it compares equal to an unmapped source
+	// address regardless of 4-in-6 representation.
 	var (
 		cachedLocalIPStr string
-		cachedLocalIP    net.IP
+		cachedLocalIP    netip.Addr
 	)
 
 	// errStreak counts consecutive read failures. A handful of instant
@@ -167,7 +169,7 @@ func (cfg *CommsConfig) receiveLoop(ctx context.Context, pc *PortChannel, rt *Co
 		default:
 		}
 
-		n, src, err := pc.Receiver.ReadFromUDP(buf)
+		n, src, err := pc.Receiver.ReadFromUDPAddrPort(buf)
 		if err == nil {
 			pc.RxPkts.Add(1)
 
@@ -207,11 +209,23 @@ func (cfg *CommsConfig) receiveLoop(ctx context.Context, pc *PortChannel, rt *Co
 		if p := rt.LocalIP.Load(); p != nil {
 			if s := *p; s != cachedLocalIPStr {
 				cachedLocalIPStr = s
-				cachedLocalIP = net.ParseIP(s)
+
+				// A parse failure leaves the zero Addr, which compares
+				// unequal to every source — the own-IP filter simply
+				// stays inert until a valid LocalIP is published.
+				addr, parseErr := netip.ParseAddr(s)
+				if parseErr != nil {
+					addr = netip.Addr{}
+				}
+
+				cachedLocalIP = addr.Unmap()
 			}
 		}
 
-		loopbackDrop := !cfg.Loopback && (src.IP.IsLoopback() || src.IP.Equal(cachedLocalIP))
+		// Unmap so a 4-in-6 source (::ffff:a.b.c.d) matches both the
+		// loopback check and the cached v4 local address.
+		srcAddr := src.Addr().Unmap()
+		loopbackDrop := !cfg.Loopback && (srcAddr.IsLoopback() || srcAddr == cachedLocalIP)
 
 		if loopbackDrop {
 			pc.RxLoopback.Add(1)
@@ -559,6 +573,3 @@ func (cfg *CommsConfig) webPlayoutLoop(ctx context.Context, pc *PortChannel, jit
 		}
 	}
 }
-
-// Ensure net is used (ReadFromUDP returns *net.UDPAddr).
-var _ *net.UDPAddr

--- a/internal/comms/receive.go
+++ b/internal/comms/receive.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"time"
 
+	pionrtp "github.com/pion/rtp"
+
 	"github.com/openmanet/openmanetd/internal/comms/control"
 	"github.com/openmanet/openmanetd/internal/comms/rtp"
 )
@@ -153,6 +155,11 @@ func (cfg *CommsConfig) receiveLoop(ctx context.Context, pc *PortChannel, rt *Co
 	// busy-spin this goroutine.
 	errStreak := 0
 
+	// pkt is reused across iterations so the parsed packet does not escape
+	// to the heap once per datagram (ParseIncomingInto overwrites every
+	// field; the payload is copied by the jitter push before buf is reused).
+	var pkt pionrtp.Packet
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -217,8 +224,7 @@ func (cfg *CommsConfig) receiveLoop(ctx context.Context, pc *PortChannel, rt *Co
 		}
 
 		// Parse using pion/rtp for proper header validation.
-		pkt, parseErr := rtp.ParseIncoming(buf[:n])
-		if parseErr != nil {
+		if parseErr := rtp.ParseIncomingInto(buf[:n], &pkt); parseErr != nil {
 			pc.RxParseErrs.Add(1)
 			cfg.Log.Debug().Err(parseErr).Int("bytes", n).Msg("comms: dropping non-RTP datagram")
 

--- a/internal/comms/receive_test.go
+++ b/internal/comms/receive_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -305,8 +306,8 @@ func TestPlayoutOneFrame_DecoderErrorPLCFallback(t *testing.T) {
 
 func TestReceiveLoop_DropsOwnPackets(t *testing.T) {
 	// All packets arrive from the local IP → all should be dropped.
-	localIP := net.IPv4(192, 168, 1, 1)
-	localAddr := &net.UDPAddr{IP: localIP}
+	localIP := netip.MustParseAddr("192.168.1.1")
+	localAddr := netip.AddrPortFrom(localIP, 5004)
 
 	var pkts []mockPacket
 
@@ -366,9 +367,72 @@ func TestReceiveLoop_DropsOwnPackets(t *testing.T) {
 	}
 }
 
+// TestReceiveLoop_DropsOwn4in6Packets pins the Unmap in the loopback filter:
+// a source address in 4-in-6 form (::ffff:a.b.c.d) must still match the
+// cached v4 local address. Production sockets bind udp4 and return plain v4
+// addresses, but the filter must not silently break if the socket family
+// ever changes to dual-stack.
+func TestReceiveLoop_DropsOwn4in6Packets(t *testing.T) {
+	localIP := "192.168.1.1"
+	mappedSrc := netip.AddrPortFrom(netip.MustParseAddr("::ffff:192.168.1.1"), 5004)
+
+	var pkts []mockPacket
+
+	for i := 0; i < rtp.PrebufferPackets+1; i++ {
+		raw := makeRTPBytes(t, uint16(i))
+		pkts = append(pkts, mockPacket{data: raw, src: mappedSrc})
+	}
+
+	reader := newMockReader(pkts...)
+	pc := &PortChannel{
+		cfg:      McastPortConfig{Send: true, Receive: true},
+		Receiver: rtp.NewSwappableReceiver(reader),
+	}
+	pc.SendEnabled.Store(true)
+	pc.ReceiveEnabled.Store(true)
+	pc.PlaybackBuffer = make(chan []int16, 16)
+	rt := &CommsRuntime{
+		Ports: []*PortChannel{pc},
+	}
+	rt.LocalIP.Store(&localIP)
+
+	cfg := &CommsConfig{Log: zerolog.Nop(), Loopback: false}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		cfg.receiveLoop(ctx, pc, rt)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if reader.remaining() == 0 {
+			break
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	cancel()
+	pc.Receiver.Close()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("receiveLoop did not exit")
+	}
+
+	if got := pc.RxLoopback.Load(); got != int64(rtp.PrebufferPackets+1) {
+		t.Errorf("4-in-6 own packets should all be dropped as loopback; RxLoopback=%d, want %d",
+			got, rtp.PrebufferPackets+1)
+	}
+}
+
 func TestReceiveLoop_DropsMalformedRTP(t *testing.T) {
 	// First packet is garbage; receiveLoop should log and continue rather than crash.
-	garbled := mockPacket{data: []byte{0xFF, 0x00, 0x01}, src: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4)}}
+	garbled := mockPacket{data: []byte{0xFF, 0x00, 0x01}, src: netip.MustParseAddrPort("1.2.3.4:5004")}
 	reader := newMockReader(garbled)
 
 	pc := &PortChannel{
@@ -536,7 +600,7 @@ func TestReceiveLoop_StampsLastRemoteRx(t *testing.T) {
 	cfg := &CommsConfig{Log: zerolog.Nop(), Loopback: true}
 
 	raw := makeRTPBytes(t, 0)
-	reader := newMockReader(mockPacket{data: raw, src: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4)}})
+	reader := newMockReader(mockPacket{data: raw, src: netip.MustParseAddrPort("1.2.3.4:5004")})
 	pc := &PortChannel{
 		cfg:      McastPortConfig{Send: true, Receive: true},
 		Receiver: rtp.NewSwappableReceiver(reader),
@@ -659,17 +723,17 @@ func TestRun_StopsReceiveLoopsWhenEventSourceCloses(t *testing.T) {
 // ─── receiveLoop socket-swap recovery tests ───────────────────────────────────
 
 // netErrClosedReader wraps a mockReader and translates any read error to
-// net.ErrClosed, matching the error that real *net.UDPConn.ReadFromUDP returns
+// net.ErrClosed, matching the error that a real *net.UDPConn read returns
 // after the connection is closed. This allows receiveLoop's socket-swap path
 // (errors.Is(err, net.ErrClosed) → jitter.Reset()) to be exercised in tests.
 type netErrClosedReader struct {
 	*mockReader
 }
 
-func (r *netErrClosedReader) ReadFromUDP(b []byte) (int, *net.UDPAddr, error) {
-	n, addr, err := r.mockReader.ReadFromUDP(b)
+func (r *netErrClosedReader) ReadFromUDPAddrPort(b []byte) (int, netip.AddrPort, error) {
+	n, addr, err := r.mockReader.ReadFromUDPAddrPort(b)
 	if err != nil {
-		return 0, nil, net.ErrClosed
+		return 0, netip.AddrPort{}, net.ErrClosed
 	}
 
 	return n, addr, nil
@@ -689,7 +753,7 @@ func TestReceiveLoop_SocketSwapResetsJitter(t *testing.T) {
 
 	for i := 0; i < rtp.PrebufferPackets+2; i++ {
 		raw := makeRTPBytes(t, uint16(i))
-		pkts1 = append(pkts1, mockPacket{data: raw, src: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4)}})
+		pkts1 = append(pkts1, mockPacket{data: raw, src: netip.MustParseAddrPort("1.2.3.4:5004")})
 	}
 
 	reader1 := &netErrClosedReader{newMockReader(pkts1...)}
@@ -699,7 +763,7 @@ func TestReceiveLoop_SocketSwapResetsJitter(t *testing.T) {
 
 	for i := 0; i < rtp.PrebufferPackets+2; i++ {
 		raw := makeRTPBytes(t, uint16(i))
-		pkts2 = append(pkts2, mockPacket{data: raw, src: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4)}})
+		pkts2 = append(pkts2, mockPacket{data: raw, src: netip.MustParseAddrPort("1.2.3.4:5004")})
 	}
 
 	reader2 := newMockReader(pkts2...)

--- a/internal/comms/register_close_test.go
+++ b/internal/comms/register_close_test.go
@@ -2,7 +2,7 @@ package comms
 
 import (
 	"errors"
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -211,7 +211,7 @@ type errClosingReader struct {
 	closed   bool
 }
 
-func (r *errClosingReader) ReadFromUDP(_ []byte) (int, *net.UDPAddr, error) {
+func (r *errClosingReader) ReadFromUDPAddrPort(_ []byte) (int, netip.AddrPort, error) {
 	select {} //nolint:staticcheck
 }
 

--- a/internal/comms/rtp/jitter.go
+++ b/internal/comms/rtp/jitter.go
@@ -237,12 +237,18 @@ func (jb *JitterBuffer) pushLocked(seq uint16, payload []byte) bool {
 		return false
 	}
 
+	// One clock read per push, shared by the idle check below and the
+	// lastPush stamp at the end — pushLocked runs under the mutex the
+	// playback callback contends on, so redundant time.Now calls are
+	// pure added hold time.
+	now := jb.nowFn()
+
 	// Idle-reset safety net: if a long gap has elapsed since the last push,
 	// treat the next packet as the start of a fresh stream regardless of
 	// sequence number. Catches edge cases the SSRC check cannot, e.g. a sender
 	// that resets seq without rotating SSRC, or RFC 3550 §8.2 collision-driven
 	// SSRC rotation that the caller did not propagate.
-	if jb.init && !jb.lastPush.IsZero() && jb.nowFn().Sub(jb.lastPush) > jitterIdleResetThreshold {
+	if jb.init && !jb.lastPush.IsZero() && now.Sub(jb.lastPush) > jitterIdleResetThreshold {
 		jb.resetLocked()
 		jb.IdleResets.Add(1)
 	}
@@ -283,7 +289,7 @@ func (jb *JitterBuffer) pushLocked(seq uint16, payload []byte) bool {
 	slot.payload = buf
 	slot.valid = true
 	jb.count++
-	jb.lastPush = jb.nowFn()
+	jb.lastPush = now
 
 	return true
 }

--- a/internal/comms/rtp/mocks_test.go
+++ b/internal/comms/rtp/mocks_test.go
@@ -2,7 +2,7 @@ package rtp
 
 import (
 	"errors"
-	"net"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 )
@@ -78,7 +78,7 @@ type trackingReader struct {
 	mu     sync.Mutex
 }
 
-func (r *trackingReader) ReadFromUDP(_ []byte) (int, *net.UDPAddr, error) {
+func (r *trackingReader) ReadFromUDPAddrPort(_ []byte) (int, netip.AddrPort, error) {
 	select {} //nolint:staticcheck
 }
 
@@ -97,14 +97,14 @@ type safeCountingReader struct {
 	calls atomic.Int64
 }
 
-func (r *safeCountingReader) ReadFromUDP(b []byte) (int, *net.UDPAddr, error) {
+func (r *safeCountingReader) ReadFromUDPAddrPort(b []byte) (int, netip.AddrPort, error) {
 	r.calls.Add(1)
 
 	if len(b) > 0 {
 		b[0] = 0xAB
 	}
 
-	return 1, &net.UDPAddr{}, nil
+	return 1, netip.AddrPort{}, nil
 }
 
 func (r *safeCountingReader) Close() error { return nil }
@@ -114,7 +114,7 @@ func (r *safeCountingReader) count() int64 { return r.calls.Load() }
 // ─── mockReader (minimal version for rtp tests) ──────────────────────────────
 
 type mockPacket struct {
-	src  *net.UDPAddr
+	src  netip.AddrPort
 	data []byte
 }
 
@@ -130,7 +130,7 @@ func newMockReader(pkts ...mockPacket) *mockReader {
 	return &mockReader{packets: pkts, closed: make(chan struct{})}
 }
 
-func (m *mockReader) ReadFromUDP(b []byte) (int, *net.UDPAddr, error) {
+func (m *mockReader) ReadFromUDPAddrPort(b []byte) (int, netip.AddrPort, error) {
 	for {
 		m.mu.Lock()
 		if len(m.packets) > 0 {
@@ -145,7 +145,7 @@ func (m *mockReader) ReadFromUDP(b []byte) (int, *net.UDPAddr, error) {
 
 		select {
 		case <-m.closed:
-			return 0, nil, errors.New("reader closed")
+			return 0, netip.AddrPort{}, errors.New("reader closed")
 		default:
 		}
 	}

--- a/internal/comms/rtp/session.go
+++ b/internal/comms/rtp/session.go
@@ -3,6 +3,7 @@ package rtp
 import (
 	"fmt"
 	"hash/fnv"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -10,12 +11,12 @@ import (
 	"github.com/pion/interceptor/pkg/report"
 	pionrtcp "github.com/pion/rtcp"
 	pionrtp "github.com/pion/rtp"
-	"github.com/pion/rtp/codecs"
 	"github.com/rs/zerolog"
 )
 
 const (
 	PayloadTypeOpus = uint8(111)
+	rtpVersion      = 2
 	rtpClockRate    = uint32(48000)
 	FrameSamples    = uint32(960) // 20 ms at 48 kHz
 	MTU             = uint16(1400)
@@ -46,30 +47,32 @@ type Sender interface {
 	Send(payload []byte) error
 }
 
-// Session wraps a pion Packetizer and an interceptor chain that
-// generates periodic RTCP Sender Reports. One session represents one local
-// SSRC (the node running this software).
+// Session frames outbound Opus payloads as RTP packets and feeds them
+// through an interceptor chain that generates periodic RTCP Sender Reports.
+// One session represents one local SSRC (the node running this software).
 //
 // The RTCP path is one-way outbound: the SR generator fires every 5 seconds
 // and writes to the provided rtcpTransport. Inbound RTP is parsed externally
 // with ParseIncoming; the session does not handle receive stats (each
 // remote SSRC in a multicast group would require a separate receiver).
 //
-// Concurrency: Send is the sole writer to packetizer and rtpWriter. In
-// production each *Session is owned by exactly one PortChannel, and Send is
-// only called from the per-encoder broadcastEncoder.encodeLoop goroutine
-// (one writer per encodeLoop, one encodeLoop per process). The pion
+// Concurrency: Send is the sole writer to sequencer, timestamp, hdr, and
+// rtpWriter. In production each *Session is owned by exactly one PortChannel,
+// and Send is only called from the per-encoder broadcastEncoder.encodeLoop
+// goroutine (one writer per encodeLoop, one encodeLoop per process). The pion
 // SenderInterceptor's RTCP timer runs on its own goroutine but only writes
 // to the RTCP transport (bound separately at NewSession), not the RTP
-// packetizer or rtpWriter — so there is no contention with Send. Adding a
+// header state or rtpWriter — so there is no contention with Send. Adding a
 // second concurrent Send caller without external synchronization would be a
 // bug; the call invariant is enforced by code review, not a mutex.
 type Session struct {
-	log        zerolog.Logger
-	packetizer pionrtp.Packetizer
-	rtpWriter  interceptor.RTPWriter
-	intercept  interceptor.Interceptor
-	ssrc       uint32
+	log       zerolog.Logger
+	sequencer pionrtp.Sequencer
+	rtpWriter interceptor.RTPWriter
+	intercept interceptor.Interceptor
+	hdr       pionrtp.Header
+	ssrc      uint32
+	timestamp uint32
 }
 
 // SSRCFromID returns a deterministic uint32 SSRC derived from an ID string
@@ -174,42 +177,60 @@ func NewSession(
 		},
 	)
 
-	// Bind the local stream — this connects the packetizer through the
-	// interceptor chain down to baseRTPWriter.
+	// Bind the local stream — this connects Send through the interceptor
+	// chain down to baseRTPWriter.
 	rtpWriter := i.BindLocalStream(streamInfo, baseRTPWriter)
 
-	packetizer := pionrtp.NewPacketizer(
-		MTU,
-		PayloadTypeOpus,
-		ssrc,
-		&codecs.OpusPayloader{},
-		pionrtp.NewRandomSequencer(),
-		rtpClockRate,
-	)
+	s := &Session{
+		log:       log,
+		sequencer: pionrtp.NewRandomSequencer(),
+		rtpWriter: rtpWriter,
+		intercept: i,
+		ssrc:      ssrc,
+		timestamp: rand.Uint32(),
+	}
 
-	return &Session{
-		log:        log,
-		packetizer: packetizer,
-		rtpWriter:  rtpWriter,
-		intercept:  i,
-		ssrc:       ssrc,
-	}, nil
+	// Fields constant for the session lifetime are set once; Send only
+	// touches SequenceNumber and Timestamp. Marker is always set: Opus is
+	// one frame per packet, so every packet ends a talkspurt frame
+	// (matches pion Packetize, which marks the last packet of each frame).
+	s.hdr.Version = rtpVersion
+	s.hdr.Marker = true
+	s.hdr.PayloadType = PayloadTypeOpus
+	s.hdr.SSRC = ssrc
+
+	return s, nil
 }
 
-// Send encodes payload into one or more RTP packets using the Packetizer and
-// writes them through the interceptor chain (and ultimately the UDP socket).
-// For Opus, Packetize always returns exactly one packet.
+// Send frames payload as a single RTP packet and writes it through the
+// interceptor chain (and ultimately the UDP socket).
+//
+// This bypasses pion's Packetizer, which costs 4 heap allocations plus a
+// payload copy per frame (OpusPayloader.Payload copies into a fresh slice
+// inside a [][]byte, Packetize allocates the []*Packet slice and the Packet
+// struct). Building the header in the reused s.hdr field and handing the
+// payload straight to the pooled writer path makes Send allocation-free;
+// the wire format is pinned byte-for-byte by TestPionRTPSession_WireFormat.
+//
+// An empty payload emits nothing but still advances the media clock,
+// preserving pion's Packetize/SkipSamples semantics.
 //
 // Send is single-writer; see Session's type comment for the call invariant.
 func (s *Session) Send(payload []byte) error {
-	packets := s.packetizer.Packetize(payload, FrameSamples)
+	if len(payload) == 0 {
+		s.timestamp += FrameSamples
 
-	for _, pkt := range packets {
-		if _, err := s.rtpWriter.Write(&pkt.Header, pkt.Payload, nil); err != nil {
-			s.log.Debug().Err(err).Msg("comms: RTP send error")
+		return nil
+	}
 
-			return fmt.Errorf("rtp write: %w", err)
-		}
+	s.hdr.SequenceNumber = s.sequencer.NextSequenceNumber()
+	s.hdr.Timestamp = s.timestamp
+	s.timestamp += FrameSamples
+
+	if _, err := s.rtpWriter.Write(&s.hdr, payload, nil); err != nil {
+		s.log.Debug().Err(err).Msg("comms: RTP send error")
+
+		return fmt.Errorf("rtp write: %w", err)
 	}
 
 	return nil

--- a/internal/comms/rtp/session.go
+++ b/internal/comms/rtp/session.go
@@ -243,11 +243,27 @@ func (s *Session) Close() error {
 
 // ParseIncoming parses a raw UDP datagram into a pion RTP Packet.
 // Returns an error if the bytes are not a valid RTP packet.
+//
+// The returned Packet escapes to the heap; hot paths should use
+// ParseIncomingInto with a caller-owned reused Packet instead.
 func ParseIncoming(raw []byte) (*pionrtp.Packet, error) {
 	var pkt pionrtp.Packet
-	if err := pkt.Unmarshal(raw); err != nil {
-		return nil, fmt.Errorf("rtp.Packet.Unmarshal: %w", err)
+	if err := ParseIncomingInto(raw, &pkt); err != nil {
+		return nil, err
 	}
 
 	return &pkt, nil
+}
+
+// ParseIncomingInto parses a raw UDP datagram into pkt, which may be reused
+// across calls: pion's Header.Unmarshal reuses CSRC capacity and resets
+// Extensions, so every field is overwritten on each parse. pkt.Payload
+// aliases raw — the caller must copy it before raw is reused (the jitter
+// buffer's push already does).
+func ParseIncomingInto(raw []byte, pkt *pionrtp.Packet) error {
+	if err := pkt.Unmarshal(raw); err != nil {
+		return fmt.Errorf("rtp.Packet.Unmarshal: %w", err)
+	}
+
+	return nil
 }

--- a/internal/comms/rtp/session_test.go
+++ b/internal/comms/rtp/session_test.go
@@ -135,6 +135,112 @@ func TestPionRTPSession_SequenceIncrement(t *testing.T) {
 	}
 }
 
+// TestPionRTPSession_WireFormat pins the full on-wire header contract of
+// Send so the packetization internals can change without breaking
+// interoperability with deployed nodes: RTP version 2, marker bit set (one
+// Opus frame per packet), timestamp advancing by exactly FrameSamples per
+// frame, and the payload delivered byte-for-byte.
+func TestPionRTPSession_WireFormat(t *testing.T) {
+	rtpW := &mockWriter{}
+
+	sess, err := NewSession(0x1234, rtpW, &mockWriter{}, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.Close() //nolint:errcheck
+
+	payloads := [][]byte{{0xA1, 0xA2, 0xA3}, {0xB1}, {0xC1, 0xC2}}
+	for _, p := range payloads {
+		if err := sess.Send(p); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if len(rtpW.Packets) != len(payloads) {
+		t.Fatalf("expected %d packets; got %d", len(payloads), len(rtpW.Packets))
+	}
+
+	var prev pionrtp.Packet
+
+	for i, raw := range rtpW.Packets {
+		var pkt pionrtp.Packet
+		if err := pkt.Unmarshal(raw); err != nil {
+			t.Fatalf("packet %d invalid: %v", i, err)
+		}
+
+		if pkt.Version != 2 {
+			t.Errorf("packet %d: version got %d, want 2", i, pkt.Version)
+		}
+
+		if !pkt.Marker {
+			t.Errorf("packet %d: marker bit not set", i)
+		}
+
+		if pkt.Padding || pkt.Extension {
+			t.Errorf("packet %d: unexpected padding/extension flags", i)
+		}
+
+		if string(pkt.Payload) != string(payloads[i]) {
+			t.Errorf("packet %d: payload got %v, want %v", i, pkt.Payload, payloads[i])
+		}
+
+		if i > 0 {
+			if got := pkt.Timestamp - prev.Timestamp; got != FrameSamples {
+				t.Errorf("packet %d: timestamp stride got %d, want %d", i, got, FrameSamples)
+			}
+
+			if got := pkt.SequenceNumber - prev.SequenceNumber; got != 1 {
+				t.Errorf("packet %d: seq stride got %d, want 1", i, got)
+			}
+		}
+
+		prev = pkt
+	}
+}
+
+// TestPionRTPSession_EmptyPayload pins the empty-frame contract: nothing is
+// written to the wire, but the timestamp still advances by FrameSamples so a
+// receiver sees the gap in media time (RFC 3550 semantics preserved from
+// pion's Packetize/SkipSamples behavior).
+func TestPionRTPSession_EmptyPayload(t *testing.T) {
+	rtpW := &mockWriter{}
+
+	sess, err := NewSession(1, rtpW, &mockWriter{}, zerolog.Nop())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.Close() //nolint:errcheck
+
+	if err := sess.Send([]byte{1}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sess.Send(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sess.Send([]byte{2}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rtpW.Packets) != 2 {
+		t.Fatalf("expected 2 packets (empty frame skipped); got %d", len(rtpW.Packets))
+	}
+
+	var first, second pionrtp.Packet
+	if err := first.Unmarshal(rtpW.Packets[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := second.Unmarshal(rtpW.Packets[1]); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := second.Timestamp - first.Timestamp; got != 2*FrameSamples {
+		t.Errorf("timestamp stride across skipped frame: got %d, want %d", got, 2*FrameSamples)
+	}
+}
+
 func TestPionRTPSession_Close(t *testing.T) {
 	sess, err := NewSession(1, &mockWriter{}, &mockWriter{}, zerolog.Nop())
 	if err != nil {

--- a/internal/comms/rtp/session_test.go
+++ b/internal/comms/rtp/session_test.go
@@ -50,6 +50,84 @@ func TestParseIncomingRTP_Valid(t *testing.T) {
 	}
 }
 
+func TestParseIncomingInto_Valid(t *testing.T) {
+	orig := &pionrtp.Packet{
+		Header:  pionrtp.Header{Version: 2, PayloadType: PayloadTypeOpus, SequenceNumber: 42, Timestamp: 1000, SSRC: 0xDEADBEEF},
+		Payload: []byte{1, 2, 3, 4},
+	}
+
+	raw, err := orig.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var pkt pionrtp.Packet
+	if err := ParseIncomingInto(raw, &pkt); err != nil {
+		t.Fatal(err)
+	}
+
+	if pkt.SequenceNumber != 42 {
+		t.Errorf("seq: got %d, want 42", pkt.SequenceNumber)
+	}
+
+	if pkt.SSRC != 0xDEADBEEF {
+		t.Errorf("ssrc: got 0x%X", pkt.SSRC)
+	}
+
+	if string(pkt.Payload) != string(orig.Payload) {
+		t.Errorf("payload: got %v, want %v", pkt.Payload, orig.Payload)
+	}
+}
+
+// TestParseIncomingInto_Reuse exercises the receiveLoop pattern: one Packet
+// struct reused across parses. The second parse must fully overwrite the
+// first — no stale header fields or payload bytes may survive.
+func TestParseIncomingInto_Reuse(t *testing.T) {
+	first := &pionrtp.Packet{
+		Header:  pionrtp.Header{Version: 2, PayloadType: PayloadTypeOpus, SequenceNumber: 1, Timestamp: 100, SSRC: 0xAAAA},
+		Payload: []byte{9, 9, 9, 9, 9, 9},
+	}
+
+	second := &pionrtp.Packet{
+		Header:  pionrtp.Header{Version: 2, PayloadType: PayloadTypeOpus, SequenceNumber: 2, Timestamp: 200, SSRC: 0xBBBB},
+		Payload: []byte{7},
+	}
+
+	rawFirst, err := first.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawSecond, err := second.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var pkt pionrtp.Packet
+	if err := ParseIncomingInto(rawFirst, &pkt); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ParseIncomingInto(rawSecond, &pkt); err != nil {
+		t.Fatal(err)
+	}
+
+	if pkt.SequenceNumber != 2 || pkt.Timestamp != 200 || pkt.SSRC != 0xBBBB {
+		t.Errorf("stale header after reuse: seq=%d ts=%d ssrc=0x%X", pkt.SequenceNumber, pkt.Timestamp, pkt.SSRC)
+	}
+
+	if len(pkt.Payload) != 1 || pkt.Payload[0] != 7 {
+		t.Errorf("stale payload after reuse: %v", pkt.Payload)
+	}
+}
+
+func TestParseIncomingInto_Invalid(t *testing.T) {
+	var pkt pionrtp.Packet
+	if err := ParseIncomingInto([]byte{0xFF, 0x00, 0x01}, &pkt); err == nil {
+		t.Error("expected error for invalid bytes")
+	}
+}
+
 func TestParseIncomingRTP_Invalid(t *testing.T) {
 	_, err := ParseIncoming([]byte{0xFF, 0x00, 0x01})
 	if err == nil {

--- a/internal/comms/rtp/transport.go
+++ b/internal/comms/rtp/transport.go
@@ -2,7 +2,7 @@ package rtp
 
 import (
 	"io"
-	"net"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -24,8 +24,12 @@ type PacketWriter interface {
 
 // PacketReader abstracts the UDP receive path so receiveLoop can be exercised
 // with pre-seeded byte sequences in tests.
+//
+// The netip.AddrPort form is deliberate: *net.UDPConn.ReadFromUDPAddrPort is
+// allocation-free, whereas ReadFromUDP heap-allocates a *net.UDPAddr and its
+// IP slice per packet when the result crosses an interface boundary.
 type PacketReader interface {
-	ReadFromUDP(b []byte) (int, *net.UDPAddr, error)
+	ReadFromUDPAddrPort(b []byte) (int, netip.AddrPort, error)
 	Close() error
 }
 
@@ -115,11 +119,11 @@ func (s *SwappableSender) Close() error {
 // SwappableReceiver wraps a PacketReader so it can be atomically replaced at
 // runtime without races with the blocking receive loop.
 //
-// ReadFromUDP snapshots the current implementation under a read lock and then
-// releases the lock before blocking, so a concurrent swap is never blocked by
-// an in-flight I/O call. Closing the old connection after the swap unblocks
-// any in-progress ReadFromUDP on the old socket, causing receiveLoop to loop
-// back and immediately read from the new socket.
+// ReadFromUDPAddrPort snapshots the current implementation under a read lock
+// and then releases the lock before blocking, so a concurrent swap is never
+// blocked by an in-flight I/O call. Closing the old connection after the swap
+// unblocks any in-progress read on the old socket, causing receiveLoop to
+// loop back and immediately read from the new socket.
 type SwappableReceiver struct {
 	impl PacketReader
 	mu   sync.RWMutex
@@ -129,13 +133,13 @@ func NewSwappableReceiver(r PacketReader) *SwappableReceiver {
 	return &SwappableReceiver{impl: r}
 }
 
-// ReadFromUDP satisfies PacketReader.
-func (r *SwappableReceiver) ReadFromUDP(b []byte) (int, *net.UDPAddr, error) {
+// ReadFromUDPAddrPort satisfies PacketReader.
+func (r *SwappableReceiver) ReadFromUDPAddrPort(b []byte) (int, netip.AddrPort, error) {
 	r.mu.RLock()
 	impl := r.impl
 	r.mu.RUnlock()
 
-	return impl.ReadFromUDP(b)
+	return impl.ReadFromUDPAddrPort(b)
 }
 
 // Close satisfies PacketReader and closes the current underlying reader.
@@ -149,7 +153,7 @@ func (r *SwappableReceiver) Close() error {
 
 // Swap atomically replaces the underlying PacketReader and returns the
 // previous one so the caller can close it (which unblocks any in-flight
-// ReadFromUDP on the old connection).
+// read on the old connection).
 func (r *SwappableReceiver) Swap(newR PacketReader) PacketReader {
 	r.mu.Lock()
 	old := r.impl

--- a/internal/comms/rtp/transport_test.go
+++ b/internal/comms/rtp/transport_test.go
@@ -1,7 +1,7 @@
 package rtp
 
 import (
-	"net"
+	"net/netip"
 	"sync"
 	"testing"
 	"time"
@@ -225,13 +225,13 @@ func TestSwappableSender_StressWritersAndSwapper(t *testing.T) {
 // ─── SwappableReceiver tests ──────────────────────────────────────────────────
 
 func TestSwappableReceiver_ReadsFromInitialImpl(t *testing.T) {
-	src := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+	src := netip.MustParseAddrPort("127.0.0.1:1234")
 	r := newMockReader(mockPacket{src: src, data: []byte{42}})
 	sr := NewSwappableReceiver(r)
 
 	buf := make([]byte, 10)
 
-	n, addr, err := sr.ReadFromUDP(buf)
+	n, addr, err := sr.ReadFromUDPAddrPort(buf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +282,7 @@ func TestSwappableReceiver_CloseUnblocksRead(t *testing.T) {
 		defer close(done)
 
 		buf := make([]byte, 10)
-		_, _, _ = sr.ReadFromUDP(buf)
+		_, _, _ = sr.ReadFromUDPAddrPort(buf)
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -292,13 +292,13 @@ func TestSwappableReceiver_CloseUnblocksRead(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(300 * time.Millisecond):
-		t.Error("Close should unblock ReadFromUDP")
+		t.Error("Close should unblock ReadFromUDPAddrPort")
 	}
 }
 
 // TestSwappableReceiver_ConcurrentSwapAndRead verifies that simultaneous
-// ReadFromUDP calls and swap calls do not produce a data race under the
-// race detector. The pattern mirrors TestSwappableSender_ConcurrentWritesAndSwap.
+// read calls and swap calls do not produce a data race under the race
+// detector. The pattern mirrors TestSwappableSender_ConcurrentWritesAndSwap.
 func TestSwappableReceiver_ConcurrentSwapAndRead(t *testing.T) {
 	r1 := &safeCountingReader{}
 	r2 := &safeCountingReader{}
@@ -320,7 +320,7 @@ func TestSwappableReceiver_ConcurrentSwapAndRead(t *testing.T) {
 			buf := make([]byte, 10)
 
 			for j := 0; j < readsEach; j++ {
-				_, _, _ = sr.ReadFromUDP(buf)
+				_, _, _ = sr.ReadFromUDPAddrPort(buf)
 			}
 		}()
 	}


### PR DESCRIPTION
Phase 1 of the comms hot-path review (follows #158): eliminate every avoidable heap allocation on the steady-state RTP send and receive paths. At the 50 Hz frame rate these were ~200 allocs/s per TX port and ~150 allocs/s per receiving port per active talker — constant GC pressure on the embedded ARM/MIPS targets the pooling architecture was built to protect.

Each change was measured in isolation with `-count=6` baselines and benchstat; full output in each commit body.

## Changes

**TX: bypass pion `Packetize`** — pion v1.10.5's `Packetize` costs 4 heap allocations plus a full payload copy per frame (`OpusPayloader.Payload` copies into a fresh slice in a `[][]byte`, `Packetize` allocates the `[]*Packet` and the `Packet`). `Session` now owns the `Sequencer` and media-clock timestamp, fills a header field reused across calls, and hands the payload straight to the existing pooled marshal path. The reused field matters: a stack header passed by pointer through `interceptor.RTPWriter` escapes. Safe under the documented single-writer invariant; the `SenderInterceptor` reads scalar fields synchronously and retains nothing.

**RX: reuse one parsed packet** — `ParseIncoming` escaped a ~100-byte `pionrtp.Packet` per datagram. New `ParseIncomingInto` parses into a packet hoisted above the read loop; pion's `Header.Unmarshal` is reuse-safe by design (CSRC capacity reuse, `Extensions[:0]`).

**RX: `netip` socket read** — `ReadFromUDP` through the `PacketReader` interface heap-allocated the `*net.UDPAddr` + IP slice per packet. The interface is now `ReadFromUDPAddrPort` (`netip.AddrPort` is a value type; `*net.UDPConn` supports it natively). The loopback filter becomes a value comparison with both sides `Unmap()`ed so 4-in-6 sources still match.

**Jitter buffer: one clock read per push** — `pushLocked` called `nowFn()` twice per accepted push inside the mutex the playback callback contends on; now one shared reading.

## Wire compatibility

The RTP wire format is pinned byte-for-byte by new characterization tests written green against the old `Packetize` path before the swap: version 2, marker set, random initial seq/timestamp, timestamp stride `FrameSamples` including skipped empty frames, payload intact (`TestPionRTPSession_WireFormat`, `TestPionRTPSession_EmptyPayload`).

## Results (linux/arm64, count=6, benchstat)

| benchmark | time | allocs |
|---|---|---|
| `RTPSessionSend` | 163.1n → 72.9n (−55%, p=0.002) | 4 → 0 (−336 B) |
| `ParseIncomingRTP` | 36.3n → 5.7n (−84%, p=0.002) | 1 → 0 (−144 B) |
| `ReceiverRead` | ~ (syscall-dominated) | 2 → 0 (−52 B, p=0.002) |
| `JitterPushPop` | 108.6n → 76.0n (−30%, p=0.002) | 0 → 0 |

Steady-state hardware-mode TX and RX hot paths are now 0 allocs/frame and 0 allocs/packet.

## Safety notes

- Loopback filter behavior pinned by existing `TestReceiveLoop_DropsOwnPackets` / malformed / socket-swap tests, plus new `TestReceiveLoop_DropsOwn4in6Packets` (verified red without the `Unmap`).
- A `LocalIP` parse failure leaves the zero `netip.Addr`, which matches no source — the filter goes inert rather than dropping real traffic.
- Production sockets bind `udp4`, so sources arrive as plain v4; the `Unmap` is insurance against a future dual-stack change.
- `BenchmarkJitterPushPop`'s pre-existing 24 B/op (slice-header re-boxing in `ReleasePayload`) is unchanged and out of scope.

## Verification

- `make lint-go` — 0 issues
- `make test` — pass
- `make test-race` — pass, no data races
- `make integration-test` — pass
- `go build ./...` — clean

