### PR TITLE
perf(comms): allocation-free, low-latency web-mode RX bridge

### DIFF
--- a/docs/instrumentation-snapshot.md
+++ b/docs/instrumentation-snapshot.md
@@ -151,8 +151,10 @@ audio bridge that ships them to browser clients.
 
 | Field | Unit | Meaning |
 |---|---|---|
-| `rx_push_in` | count | Monotonic count of frames offered to the bridge (every `PushRxFrame` invocation). |
+| `rx_push_in` | count | Monotonic count of frames offered to the bridge (every `PushRxFrame` invocation). Frames only reach the bridge while at least one consumer is attached — see `rx_gated_no_consumer`. |
 | `rx_push_drop` | count | Monotonic count of frames dropped because the bridge's internal channel was full. Compute `rx_push_drop / rx_push_in` — sustained ratios above ~1% mean the browser client is not draining RX fast enough. |
+| `rx_gated_no_consumer` | count | Monotonic count of frames the playout drain discarded without offering to the bridge because no RPC stream was attached. Rising while `consumers` is 0 is normal idle web mode (an unattended node receiving traffic), not loss. |
+| `consumers` | gauge | Number of `StreamAudioRx` RPC streams currently attached. When 0, `rx_push_in` stops advancing by design and `rx_gated_no_consumer` advances instead. |
 
 #### `comms.fec_adapter`
 

--- a/docs/instrumentation-snapshot.md
+++ b/docs/instrumentation-snapshot.md
@@ -152,7 +152,7 @@ audio bridge that ships them to browser clients.
 | Field | Unit | Meaning |
 |---|---|---|
 | `rx_push_in` | count | Monotonic count of frames offered to the bridge (every `PushRxFrame` invocation). Frames only reach the bridge while at least one consumer is attached — see `rx_gated_no_consumer`. |
-| `rx_push_drop` | count | Monotonic count of frames dropped because the bridge's internal channel was full. Compute `rx_push_drop / rx_push_in` — sustained ratios above ~1% mean the browser client is not draining RX fast enough. |
+| `rx_push_drop` | count | Monotonic count of frames discarded by the bridge: the *oldest* queued frame evicted when the ~200 ms channel is full (drop-oldest — the consumer resumes on fresh audio, never more than ~200 ms behind live), plus any stale frames flushed when the first consumer attaches. Compute `rx_push_drop / rx_push_in` — sustained ratios above ~1% mean the browser client is not draining RX fast enough. |
 | `rx_gated_no_consumer` | count | Monotonic count of frames the playout drain discarded without offering to the bridge because no RPC stream was attached. Rising while `consumers` is 0 is normal idle web mode (an unattended node receiving traffic), not loss. |
 | `consumers` | gauge | Number of `StreamAudioRx` RPC streams currently attached. When 0, `rx_push_in` stops advancing by design and `rx_gated_no_consumer` advances instead. |
 

--- a/internal/comms/receive.go
+++ b/internal/comms/receive.go
@@ -469,9 +469,10 @@ func (cfg *CommsConfig) webPlayoutLoop(ctx context.Context, pc *PortChannel, jit
 				continue
 			}
 
-			cp := make([]byte, len(payload))
-			copy(cp, payload)
-			rt.WebBridge.PushRxFrame(cp)
+			// PushRxFrame copies into a bridge-pooled buffer, so the
+			// jitter payload can be released immediately — the whole
+			// hand-off is allocation-free.
+			rt.WebBridge.PushRxFrame(payload)
 			jitter.ReleasePayload(payload)
 		}
 	}

--- a/internal/comms/receive.go
+++ b/internal/comms/receive.go
@@ -458,6 +458,17 @@ func (cfg *CommsConfig) webPlayoutLoop(ctx context.Context, pc *PortChannel, jit
 
 			popped++
 
+			// No browser stream attached: still pop (the cursor must
+			// advance and the pooled payload must recycle) but skip the
+			// copy and the bridge hand-off entirely. This is web mode's
+			// common idle state — an unattended node receiving traffic.
+			if !rt.WebBridge.HasConsumer() {
+				rt.WebBridge.RxGatedNoConsumer.Add(1)
+				jitter.ReleasePayload(payload)
+
+				continue
+			}
+
 			cp := make([]byte, len(payload))
 			copy(cp, payload)
 			rt.WebBridge.PushRxFrame(cp)

--- a/internal/comms/receive_test.go
+++ b/internal/comms/receive_test.go
@@ -917,9 +917,11 @@ func TestWebPlayoutLoop_ForwardsRawOpus(t *testing.T) {
 	// The raw Opus bytes should arrive on the bridge's RX channel.
 	select {
 	case frame := <-bridge.RxFrames():
-		if len(frame) != 3 || frame[0] != 0xAA || frame[1] != 0xBB || frame[2] != 0xCC {
-			t.Errorf("unexpected frame data: %v", frame)
+		if d := frame.Data(); len(d) != 3 || d[0] != 0xAA || d[1] != 0xBB || d[2] != 0xCC {
+			t.Errorf("unexpected frame data: %v", d)
 		}
+
+		frame.Release()
 	case <-time.After(500 * time.Millisecond):
 		t.Error("timed out waiting for raw Opus frame on web bridge")
 	}
@@ -957,9 +959,11 @@ func TestWebPlayoutLoop_MultipleFrames(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		select {
 		case frame := <-bridge.RxFrames():
-			if len(frame) != 1 || frame[0] != byte(i) {
-				t.Errorf("frame %d: got %v, want [%d]", i, frame, i)
+			if d := frame.Data(); len(d) != 1 || d[0] != byte(i) {
+				t.Errorf("frame %d: got %v, want [%d]", i, d, i)
 			}
+
+			frame.Release()
 		case <-time.After(500 * time.Millisecond):
 			t.Fatalf("timed out waiting for frame %d", i)
 		}
@@ -1156,9 +1160,11 @@ func TestWebPlayoutLoop_DoesNotAdvanceCursorOnSafetyPoll(t *testing.T) {
 
 	select {
 	case frame := <-bridge.RxFrames():
-		if len(frame) != 1 || frame[0] != 0xBB {
-			t.Errorf("unexpected frame bytes: %v", frame)
+		if d := frame.Data(); len(d) != 1 || d[0] != 0xBB {
+			t.Errorf("unexpected frame bytes: %v", d)
 		}
+
+		frame.Release()
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("seq=101 frame never reached bridge (regression)")
 	}

--- a/internal/comms/receive_test.go
+++ b/internal/comms/receive_test.go
@@ -847,6 +847,55 @@ func TestReceiveLoop_SocketSwapResetsJitter(t *testing.T) {
 // Opus payloads from the jitter buffer to the WebAudioBridge for streaming
 // to the browser. The malgo playback stream is not opened and playoutOneFrame is not used.
 
+// TestWebPlayoutLoop_GatesWhenNoConsumer pins the idle-web-mode contract:
+// with no RPC stream attached to the bridge, the drain must still empty the
+// jitter buffer (so the cursor advances and pool buffers recycle) but must
+// not copy or offer frames to the bridge channel.
+func TestWebPlayoutLoop_GatesWhenNoConsumer(t *testing.T) {
+	cfg := newSilentComms()
+	rt, pc := newReceiveRuntime()
+
+	bridge := webaudio.NewBridge(zerolog.Nop(), func(payload []byte) {
+		cfg.sendToAllPorts(rt, payload)
+	})
+	rt.WebBridge = bridge
+	// Deliberately no AddConsumer: the browser tab is closed.
+
+	jb := rtp.NewJitterBuffer(1, 16)
+	for i := range uint16(5) {
+		jb.Push(i, []byte{byte(i)})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	go cfg.webPlayoutLoop(ctx, pc, jb, rt)
+
+	// Wait until the drain has consumed everything the jitter buffer holds.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if bridge.RxGatedNoConsumer.Load() == 5 {
+			break
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := bridge.RxGatedNoConsumer.Load(); got != 5 {
+		t.Fatalf("gated-frame counter: got %d, want 5", got)
+	}
+
+	if got := bridge.RxPushIn.Load(); got != 0 {
+		t.Errorf("no frame should be offered to the bridge without a consumer; RxPushIn=%d", got)
+	}
+
+	select {
+	case f := <-bridge.RxFrames():
+		t.Errorf("bridge channel should stay empty without a consumer; got frame %v", f)
+	default:
+	}
+}
+
 func TestWebPlayoutLoop_ForwardsRawOpus(t *testing.T) {
 	cfg := newSilentComms()
 	rt, pc := newReceiveRuntime()
@@ -855,6 +904,7 @@ func TestWebPlayoutLoop_ForwardsRawOpus(t *testing.T) {
 		cfg.sendToAllPorts(rt, payload)
 	})
 	rt.WebBridge = bridge
+	bridge.AddConsumer() // this test reads RxFrames directly
 
 	jb := rtp.NewJitterBuffer(1, 16)
 	jb.Push(0, []byte{0xAA, 0xBB, 0xCC})
@@ -892,6 +942,7 @@ func TestWebPlayoutLoop_MultipleFrames(t *testing.T) {
 		cfg.sendToAllPorts(rt, payload)
 	})
 	rt.WebBridge = bridge
+	bridge.AddConsumer() // this test reads RxFrames directly
 
 	jb := rtp.NewJitterBuffer(1, 16)
 	for i := 0; i < 5; i++ {
@@ -926,6 +977,7 @@ func TestWebPlayoutLoop_DeliversWhileBroadcasting(t *testing.T) {
 		cfg.sendToAllPorts(rt, payload)
 	})
 	rt.WebBridge = bridge
+	bridge.AddConsumer() // this test reads RxFrames directly
 	rt.Broadcasting.Store(true)
 
 	jb := rtp.NewJitterBuffer(1, 16)
@@ -1066,6 +1118,7 @@ func TestWebPlayoutLoop_DoesNotAdvanceCursorOnSafetyPoll(t *testing.T) {
 		cfg.sendToAllPorts(rt, payload)
 	})
 	rt.WebBridge = bridge
+	bridge.AddConsumer() // this test reads RxFrames directly
 
 	jb := rtp.NewJitterBuffer(1, 16)
 

--- a/internal/comms/receive_test.go
+++ b/internal/comms/receive_test.go
@@ -891,7 +891,8 @@ func TestWebPlayoutLoop_GatesWhenNoConsumer(t *testing.T) {
 
 	select {
 	case f := <-bridge.RxFrames():
-		t.Errorf("bridge channel should stay empty without a consumer; got frame %v", f)
+		t.Errorf("bridge channel should stay empty without a consumer; got frame %v", f.Data())
+		f.Release()
 	default:
 	}
 }
@@ -993,8 +994,9 @@ func TestWebPlayoutLoop_DeliversWhileBroadcasting(t *testing.T) {
 	go cfg.webPlayoutLoop(ctx, pc, jb, rt)
 
 	select {
-	case <-bridge.RxFrames():
+	case f := <-bridge.RxFrames():
 		// OK — frame delivered as expected.
+		f.Release()
 	case <-ctx.Done():
 		t.Error("bridge should receive frames in web mode even while broadcasting")
 	}
@@ -1141,7 +1143,8 @@ func TestWebPlayoutLoop_DoesNotAdvanceCursorOnSafetyPoll(t *testing.T) {
 	// Drain the seed frame so the loop observes expected=101 with an
 	// empty buffer.
 	select {
-	case <-bridge.RxFrames():
+	case f := <-bridge.RxFrames():
+		f.Release()
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("seed frame never reached bridge")
 	}

--- a/internal/comms/webaudio/bench_test.go
+++ b/internal/comms/webaudio/bench_test.go
@@ -1,0 +1,30 @@
+package webaudio
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// BenchmarkWebDrain measures the per-frame cost of delivering one Opus
+// payload from the web playout drain to the RPC consumer: the defensive
+// copy webPlayoutLoop makes so the jitter buffer's pooled payload can be
+// released, the bridge hand-off, and the consumer receive.
+func BenchmarkWebDrain(b *testing.B) {
+	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
+
+	payload := make([]byte, 100) // typical Opus 20 ms frame
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		// Mirror the webPlayoutLoop drain: copy the pooled payload to a
+		// heap slice, then offer it to the bridge.
+		cp := make([]byte, len(payload))
+		copy(cp, payload)
+		bridge.PushRxFrame(cp)
+
+		<-bridge.RxFrames()
+	}
+}

--- a/internal/comms/webaudio/bench_test.go
+++ b/internal/comms/webaudio/bench_test.go
@@ -19,12 +19,11 @@ func BenchmarkWebDrain(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		// Mirror the webPlayoutLoop drain: copy the pooled payload to a
-		// heap slice, then offer it to the bridge.
-		cp := make([]byte, len(payload))
-		copy(cp, payload)
-		bridge.PushRxFrame(cp)
+		// Mirror the webPlayoutLoop drain and RPC consumer: the bridge
+		// copies into a pooled buffer, the consumer releases after use.
+		bridge.PushRxFrame(payload)
 
-		<-bridge.RxFrames()
+		f := <-bridge.RxFrames()
+		f.Release()
 	}
 }

--- a/internal/comms/webaudio/bridge.go
+++ b/internal/comms/webaudio/bridge.go
@@ -7,6 +7,7 @@
 package webaudio
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/rs/zerolog"
@@ -16,6 +17,41 @@ import (
 // multicast port. The parent package captures this callback at bridge
 // construction so webaudio has no knowledge of ports or runtime state.
 type SendFn func(opusData []byte)
+
+// maxFrameBytes is the pool buffer capacity for RX frames. RFC 6716 caps a
+// single Opus frame at 1275 bytes, and the jitter buffer upstream rejects
+// anything larger, so every payload reaching PushRxFrame fits.
+const maxFrameBytes = 1275
+
+// Frame carries one Opus payload from the mesh through the bridge to an
+// RPC consumer. The backing buffer is pooled: the consumer must call
+// Release exactly once when done with Data (after stream.Send has
+// marshaled it), and must not retain the slice afterwards. The zero Frame
+// is inert — Data returns nil and Release is a no-op.
+type Frame struct {
+	b   *Bridge
+	buf *[]byte
+	n   int
+}
+
+// Data returns the Opus payload. Valid until Release is called.
+func (f Frame) Data() []byte {
+	if f.buf == nil {
+		return nil
+	}
+
+	return (*f.buf)[:f.n]
+}
+
+// Release returns the frame's pooled buffer to the bridge. Safe on the
+// zero Frame; must not be called twice.
+func (f Frame) Release() {
+	if f.b == nil || f.buf == nil {
+		return
+	}
+
+	f.b.framePool.Put(f.buf)
+}
 
 // Bridge connects the web RPC streaming handlers to the comms runtime.
 //
@@ -28,7 +64,12 @@ type SendFn func(opusData []byte)
 type Bridge struct {
 	log      zerolog.Logger
 	send     SendFn
-	rxFrames chan []byte
+	rxFrames chan Frame
+
+	// framePool recycles RX frame buffers so the steady-state push →
+	// consume → release cycle is allocation-free. Buffers are fixed at
+	// maxFrameBytes capacity; Frame.n carries the payload length.
+	framePool sync.Pool
 
 	// consumers counts the RPC streams currently reading RxFrames. The
 	// producer side (webPlayoutLoop) checks HasConsumer before doing any
@@ -51,11 +92,19 @@ type Bridge struct {
 // NewBridge creates a bridge wired to the given send callback and logger.
 // The rxFrames channel is sized for ~1 second of slack at 50 fps.
 func NewBridge(log zerolog.Logger, send SendFn) *Bridge {
-	return &Bridge{
+	b := &Bridge{
 		log:      log,
 		send:     send,
-		rxFrames: make(chan []byte, 50),
+		rxFrames: make(chan Frame, 50),
 	}
+
+	b.framePool.New = func() any {
+		s := make([]byte, maxFrameBytes)
+
+		return &s
+	}
+
+	return b
 }
 
 // InjectTxFrame forwards a raw Opus frame from the web client to all
@@ -99,8 +148,9 @@ func (b *Bridge) HasConsumer() bool {
 }
 
 // RxFrames returns a receive-only channel that delivers Opus frames from
-// the mesh to the RPC handler.
-func (b *Bridge) RxFrames() <-chan []byte {
+// the mesh to the RPC handler. The consumer must Release every frame it
+// receives.
+func (b *Bridge) RxFrames() <-chan Frame {
 	if b == nil {
 		return nil
 	}
@@ -108,19 +158,36 @@ func (b *Bridge) RxFrames() <-chan []byte {
 	return b.rxFrames
 }
 
-// PushRxFrame delivers a raw Opus payload for the web client. The call
-// is non-blocking; if the channel is full the frame is silently dropped.
+// PushRxFrame delivers a raw Opus payload for the web client. The payload
+// is copied into a pooled buffer, so the caller's slice may be reused the
+// moment the call returns. Non-blocking; if the channel is full the frame
+// is dropped and its buffer recycled.
 func (b *Bridge) PushRxFrame(opusData []byte) {
 	if b == nil {
 		return
 	}
 
+	// Cannot happen with a conforming upstream (the jitter buffer rejects
+	// payloads over the RFC 6716 cap); guard so a future caller cannot
+	// overrun the pooled buffer.
+	if len(opusData) > maxFrameBytes {
+		b.RxPushDrop.Add(1)
+
+		return
+	}
+
 	b.RxPushIn.Add(1)
 
+	bufPtr := b.framePool.Get().(*[]byte) //nolint:forcetypeassert
+	copy((*bufPtr)[:len(opusData)], opusData)
+
+	f := Frame{b: b, buf: bufPtr, n: len(opusData)}
+
 	select {
-	case b.rxFrames <- opusData:
+	case b.rxFrames <- f:
 	default:
 		b.RxPushDrop.Add(1)
+		b.framePool.Put(bufPtr)
 		b.log.Debug().Msg("web: RX frame channel full; dropping")
 	}
 }

--- a/internal/comms/webaudio/bridge.go
+++ b/internal/comms/webaudio/bridge.go
@@ -194,6 +194,11 @@ func (b *Bridge) PushRxFrame(opusData []byte) {
 		return
 	}
 
+	// RxPushIn counts every invocation, including rejected ones — the
+	// snapshot doc defines it that way, and it keeps the
+	// rx_push_drop / rx_push_in triage ratio bounded at 1.
+	b.RxPushIn.Add(1)
+
 	// Cannot happen with a conforming upstream (the jitter buffer rejects
 	// payloads over the RFC 6716 cap); guard so a future caller cannot
 	// overrun the pooled buffer.
@@ -202,8 +207,6 @@ func (b *Bridge) PushRxFrame(opusData []byte) {
 
 		return
 	}
-
-	b.RxPushIn.Add(1)
 
 	bufPtr := b.framePool.Get().(*[]byte) //nolint:forcetypeassert
 	copy((*bufPtr)[:len(opusData)], opusData)
@@ -215,11 +218,14 @@ func (b *Bridge) PushRxFrame(opusData []byte) {
 	default:
 		// Full: evict the oldest frame (drop-oldest) so the consumer
 		// resumes on the freshest audio — for PTT voice, fresh beats
-		// stale — then retry the send once.
+		// stale — then retry the send once. Each branch logs what
+		// actually happened; a consumer draining between the selects
+		// means nothing is dropped at all, which must not log as a drop.
 		select {
 		case old := <-b.rxFrames:
 			b.RxPushDrop.Add(1)
 			old.Release()
+			b.log.Debug().Msg("web: RX frame channel full; evicted oldest")
 		default:
 			// A consumer drained the channel between our two selects;
 			// nothing to evict.
@@ -232,8 +238,7 @@ func (b *Bridge) PushRxFrame(opusData []byte) {
 			// new frame rather than looping.
 			b.RxPushDrop.Add(1)
 			b.framePool.Put(bufPtr)
+			b.log.Debug().Msg("web: RX frame channel contended; dropped newest")
 		}
-
-		b.log.Debug().Msg("web: RX frame channel full; dropped oldest")
 	}
 }

--- a/internal/comms/webaudio/bridge.go
+++ b/internal/comms/webaudio/bridge.go
@@ -23,6 +23,14 @@ type SendFn func(opusData []byte)
 // anything larger, so every payload reaching PushRxFrame fits.
 const maxFrameBytes = 1275
 
+// rxFrameDepth bounds the RX channel at ~200 ms of slack (10 frames at
+// 50 fps), matching the pipeline's latency budget. Depth beyond that only
+// adds staleness: the jitter buffer upstream already owns ordering and
+// depth, and PushRxFrame evicts the oldest frame when full, so a stalled
+// browser consumer resumes at most 200 ms behind live audio instead of
+// pinned a full second back.
+const rxFrameDepth = 10
+
 // Frame carries one Opus payload from the mesh through the bridge to an
 // RPC consumer. The backing buffer is pooled: the consumer must call
 // Release exactly once when done with Data (after stream.Send has
@@ -90,12 +98,11 @@ type Bridge struct {
 }
 
 // NewBridge creates a bridge wired to the given send callback and logger.
-// The rxFrames channel is sized for ~1 second of slack at 50 fps.
 func NewBridge(log zerolog.Logger, send SendFn) *Bridge {
 	b := &Bridge{
 		log:      log,
 		send:     send,
-		rxFrames: make(chan Frame, 50),
+		rxFrames: make(chan Frame, rxFrameDepth),
 	}
 
 	b.framePool.New = func() any {
@@ -123,12 +130,32 @@ func (b *Bridge) InjectTxFrame(opusData []byte) {
 // side only does per-frame work while at least one consumer is registered.
 // Callers must pair every AddConsumer with exactly one RemoveConsumer
 // (typically via defer) when the stream ends.
+//
+// The first consumer to attach (0 → 1 transition) flushes any frames still
+// queued from before it attached: those were pushed while the previous
+// consumer was detaching and may be arbitrarily old, and a new browser
+// session must start on live audio. A frame a concurrent producer pushes
+// during the flush may be discarded with them — one frame, indistinguishable
+// from an eviction. Non-first consumers never flush, so an active stream is
+// not robbed of frames it is about to read.
 func (b *Bridge) AddConsumer() {
 	if b == nil {
 		return
 	}
 
-	b.consumers.Add(1)
+	if b.consumers.Add(1) != 1 {
+		return
+	}
+
+	for {
+		select {
+		case f := <-b.rxFrames:
+			b.RxPushDrop.Add(1)
+			f.Release()
+		default:
+			return
+		}
+	}
 }
 
 // RemoveConsumer deregisters an RPC stream previously registered with
@@ -186,8 +213,27 @@ func (b *Bridge) PushRxFrame(opusData []byte) {
 	select {
 	case b.rxFrames <- f:
 	default:
-		b.RxPushDrop.Add(1)
-		b.framePool.Put(bufPtr)
-		b.log.Debug().Msg("web: RX frame channel full; dropping")
+		// Full: evict the oldest frame (drop-oldest) so the consumer
+		// resumes on the freshest audio — for PTT voice, fresh beats
+		// stale — then retry the send once.
+		select {
+		case old := <-b.rxFrames:
+			b.RxPushDrop.Add(1)
+			old.Release()
+		default:
+			// A consumer drained the channel between our two selects;
+			// nothing to evict.
+		}
+
+		select {
+		case b.rxFrames <- f:
+		default:
+			// Concurrent producers refilled the channel first; drop the
+			// new frame rather than looping.
+			b.RxPushDrop.Add(1)
+			b.framePool.Put(bufPtr)
+		}
+
+		b.log.Debug().Msg("web: RX frame channel full; dropped oldest")
 	}
 }

--- a/internal/comms/webaudio/bridge.go
+++ b/internal/comms/webaudio/bridge.go
@@ -30,13 +30,22 @@ type Bridge struct {
 	send     SendFn
 	rxFrames chan []byte
 
-	// Diagnostic counters for the RX side. Both are monotonic since
+	// consumers counts the RPC streams currently reading RxFrames. The
+	// producer side (webPlayoutLoop) checks HasConsumer before doing any
+	// per-frame work, so an idle web node (no browser tab attached) pays
+	// nothing for RX traffic beyond draining the jitter buffer.
+	consumers atomic.Int32
+
+	// Diagnostic counters for the RX side. All are monotonic since
 	// bridge construction; consumers compute deltas across reporting
 	// windows. RxPushIn counts every PushRxFrame call (frames offered
 	// by webPlayoutLoop); RxPushDrop counts the subset that the
 	// non-blocking channel send dropped because rxFrames was full.
-	RxPushIn   atomic.Int64
-	RxPushDrop atomic.Int64
+	// RxGatedNoConsumer counts frames the playout drain discarded
+	// without offering because no consumer was attached.
+	RxPushIn          atomic.Int64
+	RxPushDrop        atomic.Int64
+	RxGatedNoConsumer atomic.Int64
 }
 
 // NewBridge creates a bridge wired to the given send callback and logger.
@@ -59,6 +68,34 @@ func (b *Bridge) InjectTxFrame(opusData []byte) {
 	}
 
 	b.send(opusData)
+}
+
+// AddConsumer registers an RPC stream as a reader of RxFrames. The producer
+// side only does per-frame work while at least one consumer is registered.
+// Callers must pair every AddConsumer with exactly one RemoveConsumer
+// (typically via defer) when the stream ends.
+func (b *Bridge) AddConsumer() {
+	if b == nil {
+		return
+	}
+
+	b.consumers.Add(1)
+}
+
+// RemoveConsumer deregisters an RPC stream previously registered with
+// AddConsumer.
+func (b *Bridge) RemoveConsumer() {
+	if b == nil {
+		return
+	}
+
+	b.consumers.Add(-1)
+}
+
+// HasConsumer reports whether at least one RPC stream is currently reading
+// RxFrames.
+func (b *Bridge) HasConsumer() bool {
+	return b != nil && b.consumers.Load() > 0
 }
 
 // RxFrames returns a receive-only channel that delivers Opus frames from

--- a/internal/comms/webaudio/bridge_test.go
+++ b/internal/comms/webaudio/bridge_test.go
@@ -90,6 +90,46 @@ func TestBridge_PushRxFrame_DropsOnFull(t *testing.T) {
 	}
 }
 
+func TestBridge_ConsumerCount(t *testing.T) {
+	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
+
+	if bridge.HasConsumer() {
+		t.Error("fresh bridge must report no consumer")
+	}
+
+	bridge.AddConsumer()
+
+	if !bridge.HasConsumer() {
+		t.Error("HasConsumer should be true after AddConsumer")
+	}
+
+	// A second concurrent stream keeps the bridge active until both detach.
+	bridge.AddConsumer()
+	bridge.RemoveConsumer()
+
+	if !bridge.HasConsumer() {
+		t.Error("HasConsumer should stay true while one consumer remains")
+	}
+
+	bridge.RemoveConsumer()
+
+	if bridge.HasConsumer() {
+		t.Error("HasConsumer should be false after the last RemoveConsumer")
+	}
+}
+
+func TestBridge_ConsumerCount_NilBridge(t *testing.T) {
+	var bridge *Bridge
+
+	// All must be nil-safe no-ops, matching the rest of the Bridge API.
+	bridge.AddConsumer()
+	bridge.RemoveConsumer()
+
+	if bridge.HasConsumer() {
+		t.Error("nil bridge must report no consumer")
+	}
+}
+
 func TestBridge_RxFrames_ReturnsReadOnlyChannel(t *testing.T) {
 	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
 

--- a/internal/comms/webaudio/bridge_test.go
+++ b/internal/comms/webaudio/bridge_test.go
@@ -114,6 +114,88 @@ func TestBridge_PushRxFrame_DropsOnFull(t *testing.T) {
 	}
 }
 
+// TestBridge_ChannelDepth pins the RX buffer at ~200 ms of slack (10
+// frames at 50 fps). The previous 1-second depth meant a stalled browser
+// consumer resumed a full second behind live audio and stayed there for
+// the rest of a continuous stream.
+func TestBridge_ChannelDepth(t *testing.T) {
+	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
+
+	if got := cap(bridge.rxFrames); got != 10 {
+		t.Errorf("rxFrames depth: got %d, want 10 (~200 ms at 50 fps)", got)
+	}
+}
+
+// TestBridge_PushRxFrame_DropsOldestOnFull pins the drop-oldest policy:
+// when the channel is full the oldest frame is evicted so a stalled-then-
+// resumed consumer hears the freshest audio, not second-old backlog. For
+// PTT voice, fresh beats stale.
+func TestBridge_PushRxFrame_DropsOldestOnFull(t *testing.T) {
+	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
+
+	depth := cap(bridge.rxFrames)
+
+	// Frames 0..depth fill the channel and then force one eviction.
+	for i := range depth + 1 {
+		bridge.PushRxFrame([]byte{byte(i)})
+	}
+
+	if got := bridge.RxPushDrop.Load(); got != 1 {
+		t.Errorf("RxPushDrop: got %d, want 1 (the evicted oldest frame)", got)
+	}
+
+	// The survivor set must be frames 1..depth: oldest evicted, newest kept.
+	for i := 1; i <= depth; i++ {
+		select {
+		case f := <-bridge.rxFrames:
+			if d := f.Data(); len(d) != 1 || d[0] != byte(i) {
+				t.Errorf("position %d: got frame %v, want [%d]", i, d, i)
+			}
+
+			f.Release()
+		default:
+			t.Fatalf("channel exhausted at position %d; want %d frames", i, depth)
+		}
+	}
+}
+
+// TestBridge_AddConsumer_FlushesStaleFrames pins the attach-time flush:
+// frames queued when the last consumer detached (possibly hours ago) must
+// not play to a newly attached browser. The 0→1 consumer transition
+// discards and recycles whatever is queued.
+func TestBridge_AddConsumer_FlushesStaleFrames(t *testing.T) {
+	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
+
+	bridge.AddConsumer()
+	bridge.PushRxFrame([]byte{0x01})
+	bridge.PushRxFrame([]byte{0x02})
+	bridge.RemoveConsumer() // consumer detached with frames still queued
+
+	bridge.AddConsumer() // hours later, a new browser attaches
+
+	select {
+	case f := <-bridge.rxFrames:
+		t.Errorf("stale frame survived consumer attach: %v", f.Data())
+	default:
+	}
+
+	// A second consumer attaching while the first is still active must NOT
+	// flush frames the active consumer is about to read.
+	bridge.PushRxFrame([]byte{0x03})
+	bridge.AddConsumer()
+
+	select {
+	case f := <-bridge.rxFrames:
+		if d := f.Data(); len(d) != 1 || d[0] != 0x03 {
+			t.Errorf("unexpected frame after second attach: %v", d)
+		}
+
+		f.Release()
+	default:
+		t.Error("frame flushed by a non-first consumer attach")
+	}
+}
+
 // TestBridge_PushRxFrame_ZeroAlloc pins the pooled hand-off: a full
 // push→receive→release cycle must not allocate once the pool is warm.
 func TestBridge_PushRxFrame_ZeroAlloc(t *testing.T) {

--- a/internal/comms/webaudio/bridge_test.go
+++ b/internal/comms/webaudio/bridge_test.go
@@ -114,6 +114,31 @@ func TestBridge_PushRxFrame_DropsOnFull(t *testing.T) {
 	}
 }
 
+// TestBridge_PushRxFrame_OversizedCountsBoth pins the counter contract on
+// the defensive oversize guard: RxPushIn counts every PushRxFrame
+// invocation (as the snapshot doc states), so a rejected oversized payload
+// must increment both counters — otherwise rx_push_drop / rx_push_in could
+// exceed 1 and mislead triage.
+func TestBridge_PushRxFrame_OversizedCountsBoth(t *testing.T) {
+	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
+
+	bridge.PushRxFrame(make([]byte, maxFrameBytes+1))
+
+	if got := bridge.RxPushIn.Load(); got != 1 {
+		t.Errorf("RxPushIn: got %d, want 1 (every invocation counts)", got)
+	}
+
+	if got := bridge.RxPushDrop.Load(); got != 1 {
+		t.Errorf("RxPushDrop: got %d, want 1 (oversized payload rejected)", got)
+	}
+
+	select {
+	case f := <-bridge.rxFrames:
+		t.Errorf("oversized payload must not be enqueued; got %v", f.Data())
+	default:
+	}
+}
+
 // TestBridge_ChannelDepth pins the RX buffer at ~200 ms of slack (10
 // frames at 50 fps). The previous 1-second depth meant a stalled browser
 // consumer resumed a full second behind live audio and stayed there for

--- a/internal/comms/webaudio/bridge_test.go
+++ b/internal/comms/webaudio/bridge_test.go
@@ -59,19 +59,43 @@ func TestBridge_PushRxFrame_Delivered(t *testing.T) {
 
 	select {
 	case got := <-bridge.RxFrames():
-		if len(got) != 2 || got[0] != 0xCA || got[1] != 0xFE {
-			t.Errorf("unexpected frame data: %v", got)
+		if d := got.Data(); len(d) != 2 || d[0] != 0xCA || d[1] != 0xFE {
+			t.Errorf("unexpected frame data: %v", d)
 		}
+
+		got.Release()
 	case <-time.After(200 * time.Millisecond):
 		t.Error("timed out waiting for RX frame")
+	}
+}
+
+// TestBridge_PushRxFrame_CopiesPayload pins the ownership contract: the
+// caller's payload may be reused (it aliases a jitter-pool buffer) the
+// moment PushRxFrame returns, so the frame in the channel must hold its
+// own copy.
+func TestBridge_PushRxFrame_CopiesPayload(t *testing.T) {
+	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
+
+	data := []byte{0x11, 0x22}
+	bridge.PushRxFrame(data)
+
+	// Caller reuses its buffer immediately.
+	data[0] = 0xEE
+	data[1] = 0xFF
+
+	got := <-bridge.RxFrames()
+	defer got.Release()
+
+	if d := got.Data(); d[0] != 0x11 || d[1] != 0x22 {
+		t.Errorf("frame must not alias the caller's buffer; got %v", d)
 	}
 }
 
 func TestBridge_PushRxFrame_DropsOnFull(t *testing.T) {
 	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
 
-	// Fill the channel (cap = 50).
-	for range 50 {
+	// Fill the channel.
+	for range cap(bridge.rxFrames) {
 		bridge.PushRxFrame([]byte{0x00})
 	}
 
@@ -87,6 +111,63 @@ func TestBridge_PushRxFrame_DropsOnFull(t *testing.T) {
 	case <-done:
 	case <-time.After(200 * time.Millisecond):
 		t.Error("PushRxFrame blocked on full channel")
+	}
+}
+
+// TestBridge_PushRxFrame_ZeroAlloc pins the pooled hand-off: a full
+// push→receive→release cycle must not allocate once the pool is warm.
+func TestBridge_PushRxFrame_ZeroAlloc(t *testing.T) {
+	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
+
+	data := make([]byte, 100)
+
+	// Warm the pool.
+	bridge.PushRxFrame(data)
+	f := <-bridge.RxFrames()
+	f.Release()
+
+	allocs := testing.AllocsPerRun(100, func() {
+		bridge.PushRxFrame(data)
+
+		got := <-bridge.RxFrames()
+		got.Release()
+	})
+
+	if allocs != 0 {
+		t.Errorf("push/receive/release cycle allocated %.1f/op; want 0", allocs)
+	}
+}
+
+// TestBridge_PushRxFrame_DropRecyclesBuffer pins the drop branch's pool
+// hygiene: a frame dropped because the channel is full must return its
+// pooled buffer, so sustained drops do not allocate either.
+func TestBridge_PushRxFrame_DropRecyclesBuffer(t *testing.T) {
+	bridge := NewBridge(zerolog.Nop(), func(_ []byte) {})
+
+	data := make([]byte, 100)
+
+	for range cap(bridge.rxFrames) {
+		bridge.PushRxFrame(data)
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		bridge.PushRxFrame(data)
+	})
+
+	if allocs != 0 {
+		t.Errorf("drop path allocated %.1f/op; want 0 (buffer must return to the pool)", allocs)
+	}
+}
+
+// TestFrame_ZeroValueReleaseIsNoop keeps Release safe on the zero Frame,
+// matching the nil-safety of the rest of the Bridge API.
+func TestFrame_ZeroValueReleaseIsNoop(t *testing.T) {
+	var f Frame
+
+	f.Release()
+
+	if d := f.Data(); len(d) != 0 {
+		t.Errorf("zero Frame Data should be empty; got %v", d)
 	}
 }
 
@@ -139,5 +220,5 @@ func TestBridge_RxFrames_ReturnsReadOnlyChannel(t *testing.T) {
 	}
 
 	// Verify it is a receive-only channel (compile-time check via type).
-	var _ <-chan []byte = ch
+	var _ <-chan Frame = ch
 }

--- a/internal/comms/webaudio/snapshot.go
+++ b/internal/comms/webaudio/snapshot.go
@@ -13,6 +13,14 @@ type BridgeSnapshot struct {
 	// rx_push_in as a ratio; sustained values above ~1% indicate the
 	// web client is not draining received audio fast enough.
 	RxPushDrop int64 `json:"rx_push_drop"`
+	// RxGatedNoConsumer is the monotonic count of frames the playout
+	// drain discarded without offering to the bridge because no RPC
+	// stream was attached. Rising while consumers is 0 is normal idle
+	// web mode, not loss.
+	RxGatedNoConsumer int64 `json:"rx_gated_no_consumer"`
+	// Consumers is the number of RPC streams currently attached to the
+	// RX side (a gauge, not a monotonic counter).
+	Consumers int32 `json:"consumers"`
 }
 
 // Snapshot copies the current counter values into dst using atomic loads.
@@ -24,4 +32,6 @@ func (b *Bridge) Snapshot(dst *BridgeSnapshot) {
 
 	dst.RxPushIn = b.RxPushIn.Load()
 	dst.RxPushDrop = b.RxPushDrop.Load()
+	dst.RxGatedNoConsumer = b.RxGatedNoConsumer.Load()
+	dst.Consumers = b.consumers.Load()
 }

--- a/internal/comms/webaudio/snapshot_test.go
+++ b/internal/comms/webaudio/snapshot_test.go
@@ -35,6 +35,25 @@ func TestBridge_Snapshot_ReadsCounters(t *testing.T) {
 	assert.Equal(t, int64(0), dst.RxPushDrop)
 }
 
+func TestBridge_Snapshot_ConsumerFields(t *testing.T) {
+	t.Parallel()
+
+	b := webaudio.NewBridge(zerolog.Nop(), nil)
+	b.AddConsumer()
+	b.RxGatedNoConsumer.Add(7)
+
+	var dst webaudio.BridgeSnapshot
+
+	b.Snapshot(&dst)
+
+	assert.Equal(t, int32(1), dst.Consumers)
+	assert.Equal(t, int64(7), dst.RxGatedNoConsumer)
+
+	b.RemoveConsumer()
+	b.Snapshot(&dst)
+	assert.Equal(t, int32(0), dst.Consumers)
+}
+
 func TestBridge_Snapshot_ZeroAlloc(t *testing.T) {
 	b := webaudio.NewBridge(zerolog.Nop(), nil)
 	b.PushRxFrame([]byte{0x01})

--- a/internal/openmanet/server/handlers/comms.go
+++ b/internal/openmanet/server/handlers/comms.go
@@ -337,6 +337,12 @@ func (c *CommsService) StreamAudioRx(ctx context.Context, _ *commsv1.StreamAudio
 		return connect.NewError(connect.CodeFailedPrecondition, errors.New("web audio bridge not active"))
 	}
 
+	// Register as a consumer so the comms-side playout drain starts doing
+	// per-frame work; with no stream attached it discards frames without
+	// copying or touching the channel.
+	bridge.AddConsumer()
+	defer bridge.RemoveConsumer()
+
 	var seq uint32
 
 	for {

--- a/internal/openmanet/server/handlers/comms.go
+++ b/internal/openmanet/server/handlers/comms.go
@@ -349,17 +349,24 @@ func (c *CommsService) StreamAudioRx(ctx context.Context, _ *commsv1.StreamAudio
 		select {
 		case <-ctx.Done():
 			return nil
-		case opusData, ok := <-bridge.RxFrames():
+		case frame, ok := <-bridge.RxFrames():
 			if !ok {
 				return nil
 			}
 
 			seq++
 
-			if err := stream.Send(&commsv1.StreamAudioRxResponse{
-				OpusData: opusData,
+			// Release after Send: the proto marshal copies the payload
+			// into the wire buffer synchronously, so the pooled frame
+			// buffer is free to recycle once Send returns.
+			err := stream.Send(&commsv1.StreamAudioRxResponse{
+				OpusData: frame.Data(),
 				Sequence: seq,
-			}); err != nil {
+			})
+
+			frame.Release()
+
+			if err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Phase 2 of the comms hot-path review (follows #158, #159): fix the two web-mode findings — the RX drain doing per-frame work with no browser attached (P3), and the drop-newest bridge channel pinning a stalled consumer a full second behind live audio (P6).

Each change was developed test-first and measured with `-count=6` benchstat baselines; full output in the commit bodies.

## Changes

**Consumer gate (P3a)** — the bridge now counts attached `StreamAudioRx` streams; the RPC handler registers on entry and deregisters on exit. With no consumer, `webPlayoutLoop`'s drain still pops the jitter buffer (the cursor must advance and pooled payloads must recycle) but skips the copy and channel hand-off entirely. Previously an unattended web node paid 50 allocs+copies+drops/s per active talker — web mode's most common state.

**Pooled frames (P3b)** — the per-frame defensive copy to a fresh heap slice is replaced by a bridge-owned `sync.Pool` of fixed 1275-byte buffers (the RFC 6716 single-frame cap, already enforced upstream by the jitter buffer). The channel carries a small `Frame` value; the handler releases the buffer after `stream.Send` marshals it; every drop path recycles. This deviates deliberately from the review's original sketch (passing jitter-pool payloads through with a release hook): jitter pools are per-`JitterBuffer` and per-port, so pass-through would leak pool buffers across packages and still pay a boxing allocation on release. The bridge-owned pool keeps `webaudio` self-contained at the cost of one ~100-byte memcpy per frame — the allocation, not the copy, was the cost.

**Drop-oldest at 200 ms (P6)** — channel depth 50 → 10 (~200 ms at 50 fps, the pipeline's latency budget); on full, the oldest frame is evicted (buffer recycled) so a stalled-then-resumed browser hears the freshest audio instead of second-old backlog, permanently. Plus an attach-time flush: frames queued when the previous consumer detached may be arbitrarily old, so the 0→1 consumer transition discards them; non-first attaches never flush an active stream's queue.

## Results (linux/arm64, count=6, benchstat)

| benchmark | time | allocs |
|---|---|---|
| `WebDrain` (push→consume→release) | 46.5n → 32.2n (−31%, p=0.002) | 1 → 0 (−112 B) |

Combined with the gate, web-mode RX is now allocation-free in both the idle and attached states.

## Observability

`BridgeSnapshot` gains `rx_gated_no_consumer` (frames discarded because no stream was attached) and `consumers` (gauge). `rx_push_drop` now counts drop-oldest evictions and attach flushes. `docs/instrumentation-snapshot.md` rows and the idle-web-mode triage heuristic ride in the same changeset per the instrumentation rule.

## Contract changes

- Anything reading `Bridge.RxFrames()` must register via `AddConsumer`/`RemoveConsumer` and `Release` every frame — the RPC handler and all tests are migrated.
- `PushRxFrame` now copies internally; the caller's slice may be reused the moment it returns (pinned by `TestBridge_PushRxFrame_CopiesPayload`).

## Verification

- `make lint-go` — 0 issues
- `make test` — pass
- `make test-race` — pass, no data races
- `make integration-test` — pass
- `go build ./...` — clean

