### PR TITLE
perf(comms): idle-cost reductions — sleeping playback streams, gated proc scan, NanoPTT lifecycle

### DIFF
--- a/docs/instrumentation-snapshot.md
+++ b/docs/instrumentation-snapshot.md
@@ -190,7 +190,7 @@ One entry per configured multicast talk group. The slice order mirrors
 | `playback_underruns` | count | Number of playback-side decode failures that had to recover via PLC (packet loss concealment). |
 | `rx_pkts` | count | Monotonic count of successful `ReadFromUDP` returns on this port's receive socket (packets the kernel handed userspace). |
 | `rx_loopback` | count | Packets dropped by the loopback filter (own-IP suppression) before reaching the RTP parser. |
-| `rx_parse_errs` | count | Packets that failed `rtp.ParseIncoming`. Sustained nonzero deltas indicate a non-RTP sender aliasing the port. |
+| `rx_parse_errs` | count | Packets that failed `rtp.ParseIncoming`. Sustained nonzero deltas indicate a non-RTP sender aliasing the port. Only counted while the port is receive-enabled — muted ports discard packets before parsing, so a muted port always shows a zero delta here regardless of traffic. |
 | `rx_pushed` | count | Packets that `PushWithSSRC` accepted into the jitter buffer. In a healthy stream, `rx_pushed ≈ rx_pkts - rx_loopback - rx_parse_errs`. |
 | `rx_push_rejected` | count | Packets that `PushWithSSRC` rejected as stale-cursor, duplicate, overflow, or oversized (payload larger than the RFC 6716 1275-byte frame cap — a conforming Opus sender never produces these). A sustained nonzero delta with `jitter.ssrc_resets` flat indicates a consumer-side cursor-advance bug, sender reordering, or a non-Opus sender aliasing the port. |
 | `web_popped_skipped` | count | `webPlayoutLoop` observed the jitter buffer advancing past a missing sequence number (only happens when the buffer is half-full of out-of-order packets). Zero on the portaudio playout path. |

--- a/internal/comms/config.go
+++ b/internal/comms/config.go
@@ -139,16 +139,16 @@ type CommsConfig struct {
 	audioRecoveryInterval time.Duration
 	// webStatInterval overrides the webPlayoutLoop stat-reporting ticker
 	// period for tests. <= 0 (production) uses webStatDefaultInterval.
-	webStatInterval time.Duration
-	ROIPVOXThreshold      float32
-	MicGain               float32
-	EnableNanoPTT         bool
-	EnableBluetoothPtt    bool
-	Enable                bool
-	Trace                 bool
-	Loopback              bool
-	Debug                 bool
-	ROIPCOSGPIOMask       byte
+	webStatInterval    time.Duration
+	ROIPVOXThreshold   float32
+	MicGain            float32
+	EnableNanoPTT      bool
+	EnableBluetoothPtt bool
+	Enable             bool
+	Trace              bool
+	Loopback           bool
+	Debug              bool
+	ROIPCOSGPIOMask    byte
 }
 
 // NewComms copies cfg and returns a pointer ready for Start.

--- a/internal/comms/config.go
+++ b/internal/comms/config.go
@@ -108,7 +108,10 @@ type CommsConfig struct {
 	startHardwareAudioFn func(rt *CommsRuntime) (func(), error)
 	// detectALSACardFn overrides ALSA card auto-detection for tests. When
 	// nil, detectALSACard falls back to control.DetectAndSetALSACard(cfg.Log).
-	detectALSACardFn         func()
+	detectALSACardFn func()
+	// readUDPDropsFn overrides the /proc/net/udp kernel-drop scan for
+	// tests. When nil, readUDPDrops falls back to readUDPSocketDrops.
+	readUDPDropsFn           func(localPort int) (int64, error)
 	BluetoothOutputDevice    string
 	NanoPTTDevicePath        string
 	CommKey                  string
@@ -134,6 +137,9 @@ type CommsConfig struct {
 	// transient ALSA error). <= 0 disables in-run recovery; applyDefaults
 	// sets the production value.
 	audioRecoveryInterval time.Duration
+	// webStatInterval overrides the webPlayoutLoop stat-reporting ticker
+	// period for tests. <= 0 (production) uses webStatDefaultInterval.
+	webStatInterval time.Duration
 	ROIPVOXThreshold      float32
 	MicGain               float32
 	EnableNanoPTT         bool

--- a/internal/comms/control/nanoptt.go
+++ b/internal/comms/control/nanoptt.go
@@ -2,34 +2,143 @@ package control
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"sync"
 
 	evdev "github.com/gvalkov/golang-evdev"
 	"github.com/rs/zerolog"
 )
 
+// nanoPTTErrStreakThreshold is the number of consecutive read failures
+// after which the event goroutine gives up and terminates. Real evdev
+// read errors (ENODEV on unplug, EBADF/closed-file after our own
+// close-on-cancel) are all persistent, so the streak exists only to
+// absorb a hypothetical transient; without a bound, a dead device fd
+// returning instantly would busy-spin this goroutine at 100% CPU.
+const nanoPTTErrStreakThreshold = 3
+
 // NanoPTTSource reads Linux input events from an evdev device and emits
 // PTTToggle on each key-press that matches the configured key code.
+//
+// The source owns the device: each enable cycle opens a fresh
+// *evdev.InputDevice (control_register.go → findCommDevice), and the
+// Events goroutine closes it on context cancellation or terminal read
+// failure. Closing the underlying file is also what unblocks a read(2)
+// parked between key events — the evdev fd is registered with the Go
+// runtime poller, mirroring the OpenVLM HID close-on-cancel pattern.
 type NanoPTTSource struct {
-	log    zerolog.Logger
-	dev    *evdev.InputDevice
-	pttKey string
+	log      zerolog.Logger
+	dev      *evdev.InputDevice
+	readOne  func() (*evdev.InputEvent, error)
+	closeDev func() error
+	pttKey   string
 }
 
 // NewNanoPTTSource constructs a NanoPTTSource that reads from dev and emits
 // a PTTToggle on each press of pttKey ("any" matches any key code, otherwise
-// the decimal evdev key code).
+// the decimal evdev key code). The source takes ownership of dev and closes
+// it when the Events goroutine exits.
 func NewNanoPTTSource(dev *evdev.InputDevice, pttKey string, log zerolog.Logger) EventSource {
 	return &NanoPTTSource{dev: dev, pttKey: pttKey, log: log}
 }
 
-// Events returns the PTT event channel for this source. The channel is closed
-// when ctx is canceled.
+// readOneEvent resolves the read through the test seam, falling back to
+// the real device.
+func (s *NanoPTTSource) readOneEvent() (*evdev.InputEvent, error) {
+	if s.readOne != nil {
+		return s.readOne()
+	}
+
+	ev, err := s.dev.ReadOne()
+	if err != nil {
+		return nil, fmt.Errorf("evdev read: %w", err)
+	}
+
+	return ev, nil
+}
+
+// matchesKey reports whether code matches the configured pttKey ("any"
+// matches every code, otherwise the decimal evdev key code).
+func (s *NanoPTTSource) matchesKey(code uint16) bool {
+	if s.pttKey == "any" {
+		return true
+	}
+
+	kc, err := strconv.Atoi(s.pttKey)
+
+	return err == nil && kc >= 0 && kc <= 65535 && code == uint16(kc)
+}
+
+// handleKeyEvent emits PTTToggle for a matching key press. Returns false
+// when a pending send was aborted by ctx cancellation (the caller should
+// exit); true otherwise.
+func (s *NanoPTTSource) handleKeyEvent(ctx context.Context, ev *evdev.InputEvent, ch chan<- PTTEvent) bool {
+	if ev.Type != evdev.EV_KEY || !s.matchesKey(ev.Code) {
+		return true
+	}
+
+	switch ev.Value {
+	case 1:
+		s.log.Debug().Msgf("Comm key press (code=%d)", ev.Code)
+
+		select {
+		case ch <- PTTToggle:
+		case <-ctx.Done():
+			return false
+		}
+	case 0:
+		s.log.Debug().Msgf("Comm key release (code=%d)", ev.Code)
+	}
+
+	return true
+}
+
+// closeDevice resolves the close through the test seam, falling back to
+// closing the real device's file (which unblocks a pending ReadOne).
+func (s *NanoPTTSource) closeDevice() error {
+	if s.closeDev != nil {
+		return s.closeDev()
+	}
+
+	if s.dev != nil && s.dev.File != nil {
+		return s.dev.File.Close()
+	}
+
+	return nil
+}
+
+// Events returns the PTT event channel for this source. The channel is
+// closed when ctx is canceled or when the device fails persistently
+// (e.g. the dongle is unplugged); either way the device is closed exactly
+// once, so no goroutine or fd survives a disable/enable cycle.
 func (s *NanoPTTSource) Events(ctx context.Context) <-chan PTTEvent {
 	ch := make(chan PTTEvent, 4)
 
 	go func() {
 		defer close(ch)
+
+		var closeOnce sync.Once
+
+		closeDev := func() {
+			closeOnce.Do(func() {
+				if err := s.closeDevice(); err != nil {
+					s.log.Debug().Err(err).Msg("comms: error closing PTT device")
+				}
+			})
+		}
+
+		// Close-on-cancel: ReadOne blocks in read(2) between key events,
+		// and the context is only checked between reads — closing the
+		// file is the only way to unblock a parked read promptly.
+		stop := context.AfterFunc(ctx, closeDev)
+
+		defer func() {
+			stop()
+			closeDev()
+		}()
+
+		errStreak := 0
 
 		for {
 			select {
@@ -38,37 +147,26 @@ func (s *NanoPTTSource) Events(ctx context.Context) <-chan PTTEvent {
 			default:
 			}
 
-			ev, err := s.dev.ReadOne()
+			ev, err := s.readOneEvent()
 			if err != nil {
-				continue
-			}
-
-			if ev.Type != evdev.EV_KEY {
-				continue
-			}
-
-			match := false
-			if s.pttKey == "any" {
-				match = true
-			} else if kc, parseErr := strconv.Atoi(s.pttKey); parseErr == nil && kc >= 0 && kc <= 65535 && ev.Code == uint16(kc) {
-				match = true
-			}
-
-			if !match {
-				continue
-			}
-
-			switch ev.Value {
-			case 1:
-				s.log.Debug().Msgf("Comm key press (code=%d)", ev.Code)
-
-				select {
-				case ch <- PTTToggle:
-				case <-ctx.Done():
+				if ctx.Err() != nil {
 					return
 				}
-			case 0:
-				s.log.Debug().Msgf("Comm key release (code=%d)", ev.Code)
+
+				errStreak++
+				if errStreak >= nanoPTTErrStreakThreshold {
+					s.log.Error().Err(err).Msg("comms: PTT device read failed repeatedly; stopping event source")
+
+					return
+				}
+
+				continue
+			}
+
+			errStreak = 0
+
+			if !s.handleKeyEvent(ctx, ev, ch) {
+				return
 			}
 		}
 	}()

--- a/internal/comms/control/nanoptt_test.go
+++ b/internal/comms/control/nanoptt_test.go
@@ -1,0 +1,202 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	evdev "github.com/gvalkov/golang-evdev"
+	"github.com/rs/zerolog"
+)
+
+// fakeEvdev drives NanoPTTSource through its readOne/closeDev seams. Reads
+// return queued events, then block until Close unblocks them with an error
+// — mirroring a real evdev fd, where a blocked read(2) only returns once
+// the file is closed.
+type fakeEvdev struct {
+	mu       sync.Mutex
+	events   []*evdev.InputEvent
+	closed   chan struct{}
+	once     sync.Once
+	reads    atomic.Int64
+	closes   atomic.Int64
+	readErr  error // when set, every read fails with this error
+	blockErr error // error returned when Close unblocks a pending read
+}
+
+func newFakeEvdev(events ...*evdev.InputEvent) *fakeEvdev {
+	return &fakeEvdev{
+		events:   events,
+		closed:   make(chan struct{}),
+		blockErr: errors.New("file already closed"),
+	}
+}
+
+func (f *fakeEvdev) readOne() (*evdev.InputEvent, error) {
+	f.reads.Add(1)
+
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+
+	f.mu.Lock()
+	if len(f.events) > 0 {
+		ev := f.events[0]
+		f.events = f.events[1:]
+		f.mu.Unlock()
+
+		return ev, nil
+	}
+	f.mu.Unlock()
+
+	<-f.closed
+
+	return nil, f.blockErr
+}
+
+func (f *fakeEvdev) close() error {
+	f.closes.Add(1)
+	f.once.Do(func() { close(f.closed) })
+
+	return nil
+}
+
+func newTestNanoPTT(f *fakeEvdev, pttKey string) *NanoPTTSource {
+	return &NanoPTTSource{
+		log:      zerolog.Nop(),
+		pttKey:   pttKey,
+		readOne:  f.readOne,
+		closeDev: f.close,
+	}
+}
+
+func keyEvent(code uint16, value int32) *evdev.InputEvent {
+	return &evdev.InputEvent{Type: evdev.EV_KEY, Code: code, Value: value}
+}
+
+// TestNanoPTTSource_EmitsToggleOnPress pins the existing key handling:
+// a press (value 1) of the configured key emits PTTToggle; the release
+// (value 0) emits nothing.
+func TestNanoPTTSource_EmitsToggleOnPress(t *testing.T) {
+	f := newFakeEvdev(keyEvent(42, 1), keyEvent(42, 0))
+	s := newTestNanoPTT(f, "42")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := s.Events(ctx)
+
+	select {
+	case ev := <-ch:
+		if ev != PTTToggle {
+			t.Errorf("got event %v, want PTTToggle", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no PTTToggle emitted for key press")
+	}
+
+	// The release must not emit; the channel stays quiet until cancel.
+	select {
+	case ev, ok := <-ch:
+		if ok {
+			t.Errorf("unexpected event %v after key release", ev)
+		}
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestNanoPTTSource_IgnoresOtherKeys pins the key filter: presses of a
+// non-matching code emit nothing, and "any" matches every code.
+func TestNanoPTTSource_IgnoresOtherKeys(t *testing.T) {
+	f := newFakeEvdev(keyEvent(7, 1))
+	s := newTestNanoPTT(f, "42")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := s.Events(ctx)
+
+	select {
+	case ev, ok := <-ch:
+		if ok {
+			t.Errorf("unexpected event %v for non-matching key", ev)
+		}
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	fAny := newFakeEvdev(keyEvent(7, 1))
+	sAny := newTestNanoPTT(fAny, "any")
+
+	chAny := sAny.Events(ctx)
+
+	select {
+	case ev := <-chAny:
+		if ev != PTTToggle {
+			t.Errorf("got event %v, want PTTToggle for pttKey=any", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pttKey=any did not match key press")
+	}
+}
+
+// TestNanoPTTSource_CancelClosesDeviceAndChannel pins the leak fix: the
+// read goroutine blocks in read(2) between key events, so cancellation
+// must close the device (unblocking the read) and the event channel must
+// close — otherwise every disable/enable cycle leaks a goroutine and an
+// open evdev fd.
+func TestNanoPTTSource_CancelClosesDeviceAndChannel(t *testing.T) {
+	f := newFakeEvdev() // no events: first read blocks immediately
+	s := newTestNanoPTT(f, "any")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := s.Events(ctx)
+
+	// Let the goroutine reach the blocking read.
+	time.Sleep(20 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel close, got an event")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("event channel did not close after cancel; blocked read was never unblocked")
+	}
+
+	if f.closes.Load() == 0 {
+		t.Error("device was not closed on cancel (fd leak)")
+	}
+}
+
+// TestNanoPTTSource_TerminalOnPersistentReadError pins the busy-spin fix:
+// a permanently failing device (e.g. dongle unplugged, read returns
+// ENODEV instantly forever) must terminate the source after a bounded
+// number of attempts instead of spinning the goroutine at 100% CPU.
+func TestNanoPTTSource_TerminalOnPersistentReadError(t *testing.T) {
+	f := newFakeEvdev()
+	f.readErr = errors.New("no such device")
+	s := newTestNanoPTT(f, "any")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := s.Events(ctx)
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel close, got an event")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("source did not terminate on persistent read errors")
+	}
+
+	if got := f.reads.Load(); got > 10 {
+		t.Errorf("read attempted %d times before terminating; want a small bounded count", got)
+	}
+}

--- a/internal/comms/lifecycle.go
+++ b/internal/comms/lifecycle.go
@@ -64,20 +64,68 @@ func (cfg *CommsConfig) startHardwareAudio(rt *CommsRuntime) (cleanup func(), er
 			HasReceiver:  true,
 			Port:         pc.cfg.Port,
 			BeepBuf:      pc.PlaybackBuffer,
-			SetStream:    func(s device.AudioStream) { pcRef.PlaybackStream = s },
+			SetStream:    func(s device.AudioStream) { pcRef.setPlaybackStream(s) },
 			PlayoutFrame: func(out []int16) { cfg.playoutOneFrame(pcRef, rt, pcRef.Jitter, out) },
 		})
 	}
 
 	broadcast, cleanup, hwErr := audioInit.StartHardware(slots)
 	if hwErr != nil {
+		// The SetStream hooks may have stored streams that StartHardware's
+		// unwind already closed; detach them so a later toggle or beep can
+		// never call into a freed malgo device.
+		for _, pc := range rt.Ports {
+			pc.clearPlaybackStream()
+		}
+
 		return nil, hwErr
 	}
 
 	rt.SetBroadcast(broadcast)
 	rt.PlaybackOutputLatency = audioInit.PlaybackOutputLatency
 
-	return cleanup, nil
+	// StartHardware started every playback stream; record that, then
+	// re-sleep the streams of ports that are not receive-enabled (P4: an
+	// idle port must not keep a malgo RT thread waking every 20 ms).
+	cfg.markAndSyncPlayback(rt)
+
+	// Detach the per-port streams before the hardware cleanup closes
+	// them, for the same freed-device reason as the failure path above.
+	wrapped := func() {
+		for _, pc := range rt.Ports {
+			pc.clearPlaybackStream()
+		}
+
+		cleanup()
+	}
+
+	return wrapped, nil
+}
+
+// markAndSyncPlayback records that StartHardware started every installed
+// playback stream, then stops the streams of receive-disabled ports so
+// only enabled ports keep a running malgo device. Called after every
+// successful hardware init (boot and in-run recovery), so a recovery
+// honors toggles made while audio was down.
+func (cfg *CommsConfig) markAndSyncPlayback(rt *CommsRuntime) {
+	for _, pc := range rt.Ports {
+		if !pc.playbackStreamInstalled() {
+			continue
+		}
+
+		pc.markPlaybackRunning()
+
+		if pc.ReceiveEnabled.Load() {
+			continue
+		}
+
+		if err := pc.stopPlayback(); err != nil {
+			// Non-fatal: the stream keeps running, which is the pre-P4
+			// status quo for a disabled port, not a correctness problem.
+			cfg.Log.Warn().Err(err).Int("port", pc.cfg.Port).
+				Msg("comms: failed to sleep playback stream for disabled port")
+		}
+	}
 }
 
 const (

--- a/internal/comms/multiport_test.go
+++ b/internal/comms/multiport_test.go
@@ -370,9 +370,11 @@ func TestDrainPlaybackBuffer_MultiPort(t *testing.T) {
 	}
 }
 
-// TestBeginTransmission_BeepSentToAllPorts verifies that beginTransmission
-// queues the start-beep to every configured port's playback buffer.
-func TestBeginTransmission_BeepSentToAllPorts(t *testing.T) {
+// TestBeginTransmission_BeepSentToOnePort verifies the single-beep
+// contract: beginTransmission queues the start-beep to exactly one port —
+// the pre-P4 fan-out played N overlapping copies of the tone through dmix
+// into the same physical output device.
+func TestBeginTransmission_BeepSentToOnePort(t *testing.T) {
 	pc0 := &PortChannel{cfg: McastPortConfig{Send: true, Receive: true}}
 	pc0.SendEnabled.Store(true)
 	pc0.ReceiveEnabled.Store(true)
@@ -393,12 +395,12 @@ func TestBeginTransmission_BeepSentToAllPorts(t *testing.T) {
 	cfg := &CommsConfig{Log: zerolog.Nop()}
 	cfg.beginTransmission(rt)
 
-	if len(pc0.PlaybackBuffer) == 0 {
-		t.Error("port 0: expected start beep in playback buffer")
+	if len(pc0.PlaybackBuffer) != 1 {
+		t.Errorf("port 0: beeps queued = %d, want 1", len(pc0.PlaybackBuffer))
 	}
 
-	if len(pc1.PlaybackBuffer) == 0 {
-		t.Error("port 1: expected start beep in playback buffer")
+	if len(pc1.PlaybackBuffer) != 0 {
+		t.Errorf("port 1: beeps queued = %d, want 0 (single-beep contract)", len(pc1.PlaybackBuffer))
 	}
 }
 

--- a/internal/comms/network.go
+++ b/internal/comms/network.go
@@ -1,6 +1,8 @@
 package comms
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -74,6 +76,16 @@ func setMulticastTTL(conn *net.UDPConn, ttl int) error {
 	return nil
 }
 
+// readUDPDrops resolves the kernel-drop scan through the test seam,
+// falling back to the real /proc/net/udp reader when unset.
+func (cfg *CommsConfig) readUDPDrops(localPort int) (int64, error) {
+	if cfg.readUDPDropsFn != nil {
+		return cfg.readUDPDropsFn(localPort)
+	}
+
+	return readUDPSocketDrops(localPort)
+}
+
 // readUDPSocketDrops returns the kernel's per-socket drop counter for the
 // UDP socket bound to localPort, parsed out of /proc/net/udp and
 // /proc/net/udp6. Returns -1 with no error if no matching row is found
@@ -106,25 +118,43 @@ func readUDPSocketDrops(localPort int) (int64, error) {
 // whose local_address ends with ":<localPort>" (port in big-endian hex)
 // and returns the drops column. Returns -1 with no error when the row is
 // missing — the caller falls through to the next file.
+//
+// The file is streamed line-by-line rather than slurped, and a cheap
+// substring pre-filter skips the per-field split for the vast majority of
+// rows — a busy host's table has dozens of sockets and exactly one can
+// match. The pre-filter can false-positive when the port's hex pattern
+// appears in another column (remote address, inode); the authoritative
+// HasSuffix check on the local_address field runs after the split, so a
+// decoy row is never matched.
 func scanUDPDropsFile(path string, localPort int) (int64, error) {
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return -1, nil
 		}
 
-		return -1, fmt.Errorf("read %s: %w", path, err)
+		return -1, fmt.Errorf("open %s: %w", path, err)
 	}
+	defer f.Close() //nolint:errcheck // read-only file
 
 	wantSuffix := fmt.Sprintf(":%04X", localPort)
+	needle := []byte(wantSuffix)
 
-	lines := strings.Split(string(data), "\n")
-	for i, line := range lines {
-		if i == 0 {
-			continue // header
+	scanner := bufio.NewScanner(f)
+	first := true
+
+	for scanner.Scan() {
+		if first {
+			first = false // header row
+
+			continue
 		}
 
-		fields := strings.Fields(line)
+		if !bytes.Contains(scanner.Bytes(), needle) {
+			continue
+		}
+
+		fields := strings.Fields(scanner.Text())
 		if len(fields) < 13 {
 			continue
 		}
@@ -140,6 +170,10 @@ func scanUDPDropsFile(path string, localPort int) (int64, error) {
 		}
 
 		return drops, nil
+	}
+
+	if scanErr := scanner.Err(); scanErr != nil {
+		return -1, fmt.Errorf("scan %s: %w", path, scanErr)
 	}
 
 	return -1, nil

--- a/internal/comms/network_drops_test.go
+++ b/internal/comms/network_drops_test.go
@@ -1,0 +1,230 @@
+package comms
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/openmanet/openmanetd/internal/comms/rtp"
+	"github.com/openmanet/openmanetd/internal/comms/webaudio"
+)
+
+// writeProcUDPFixture writes a synthetic /proc/net/udp-format file and
+// returns its path. rows are appended below the standard header.
+func writeProcUDPFixture(t *testing.T, rows ...string) string {
+	t.Helper()
+
+	const header = "   sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops"
+
+	path := filepath.Join(t.TempDir(), "udp")
+	content := header + "\n" + strings.Join(rows, "\n") + "\n"
+
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return path
+}
+
+// procUDPRow renders one /proc/net/udp row for the given port and drop
+// count, matching the kernel's field layout (drops is the last field).
+func procUDPRow(port int, drops int64) string {
+	return fmt.Sprintf(
+		"  368: 00000000:%04X 00000000:0000 07 00000000:00000000 00:00000000 00000000  1000        0 27686 2 0000000000000000 %d",
+		port, drops)
+}
+
+func TestScanUDPDropsFile_MatchingRow(t *testing.T) {
+	path := writeProcUDPFixture(t,
+		procUDPRow(5000, 0),
+		procUDPRow(38801, 42),
+		procUDPRow(9999, 7),
+	)
+
+	drops, err := scanUDPDropsFile(path, 38801)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if drops != 42 {
+		t.Errorf("drops: got %d, want 42", drops)
+	}
+}
+
+func TestScanUDPDropsFile_NoMatchingRow(t *testing.T) {
+	path := writeProcUDPFixture(t, procUDPRow(5000, 3))
+
+	drops, err := scanUDPDropsFile(path, 38801)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if drops != -1 {
+		t.Errorf("drops: got %d, want -1 (row missing)", drops)
+	}
+}
+
+func TestScanUDPDropsFile_MissingFile(t *testing.T) {
+	drops, err := scanUDPDropsFile(filepath.Join(t.TempDir(), "nope"), 38801)
+	if err != nil {
+		t.Fatalf("missing file must not error (non-Linux hosts): %v", err)
+	}
+
+	if drops != -1 {
+		t.Errorf("drops: got %d, want -1", drops)
+	}
+}
+
+// TestScanUDPDropsFile_HexSuffixInOtherColumn guards the fast-path
+// pre-filter: a row whose inode/pointer happens to contain the port's hex
+// pattern must not match unless the local_address column actually ends
+// with it.
+func TestScanUDPDropsFile_HexSuffixInOtherColumn(t *testing.T) {
+	// 38801 = 0x9791; craft a non-matching row that contains ":9791"
+	// in the remote-address column only.
+	row := "  368: 00000000:1388 00000000:9791 07 00000000:00000000 00:00000000 00000000  1000        0 27686 2 0000000000000000 5"
+	path := writeProcUDPFixture(t, row, procUDPRow(38801, 42))
+
+	drops, err := scanUDPDropsFile(path, 38801)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if drops != 42 {
+		t.Errorf("drops: got %d, want 42 (decoy row must not match)", drops)
+	}
+}
+
+func TestScanUDPDropsFile_ShortRowsSkipped(t *testing.T) {
+	path := writeProcUDPFixture(t, "garbage row", procUDPRow(38801, 9))
+
+	drops, err := scanUDPDropsFile(path, 38801)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if drops != 9 {
+		t.Errorf("drops: got %d, want 9", drops)
+	}
+}
+
+// runStatTickProbe drives webPlayoutLoop with the given logger and RX
+// activity level, and reports whether the kernel-drop proc scan ran
+// during ~3 stat ticks.
+func runStatTickProbe(t *testing.T, log zerolog.Logger, withActivity bool) bool {
+	t.Helper()
+
+	var scanned atomic.Bool
+
+	cfg := &CommsConfig{
+		Log:             log,
+		Loopback:        true,
+		webStatInterval: 20 * time.Millisecond,
+		readUDPDropsFn: func(int) (int64, error) {
+			scanned.Store(true)
+
+			return 0, nil
+		},
+	}
+
+	pc := &PortChannel{cfg: McastPortConfig{Send: true, Receive: true}}
+	pc.SendEnabled.Store(true)
+	pc.ReceiveEnabled.Store(true)
+
+	rt := &CommsRuntime{Ports: []*PortChannel{pc}}
+	rt.WebBridge = webaudio.NewBridge(zerolog.Nop(), func(_ []byte) {})
+	rt.WebBridge.AddConsumer()
+
+	jb := rtp.NewJitterBuffer(1, 16)
+
+	if withActivity {
+		// RxPkts deltas are what the activity gate reads.
+		pc.RxPkts.Add(5)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		cfg.webPlayoutLoop(ctx, pc, jb, rt)
+	}()
+
+	// Let ~3 stat ticks fire, feeding fresh activity each tick when asked.
+	for range 3 {
+		time.Sleep(25 * time.Millisecond)
+
+		if withActivity {
+			pc.RxPkts.Add(5)
+		}
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("webPlayoutLoop did not exit")
+	}
+
+	return scanned.Load()
+}
+
+// TestWebStatTick_ScansOnlyWhenDebugAndActive pins the P8 gate: the
+// /proc/net/udp scan is debug-log-only telemetry, so it must not run when
+// Debug logging is off or when the port saw no RX activity in the window.
+func TestWebStatTick_ScansOnlyWhenDebugAndActive(t *testing.T) {
+	debugLog := zerolog.New(io.Discard).Level(zerolog.DebugLevel)
+	infoLog := zerolog.New(io.Discard).Level(zerolog.InfoLevel)
+
+	if !runStatTickProbe(t, debugLog, true) {
+		t.Error("scan should run with Debug enabled and RX activity")
+	}
+
+	if runStatTickProbe(t, infoLog, true) {
+		t.Error("scan must not run when Debug logging is disabled")
+	}
+
+	if runStatTickProbe(t, debugLog, false) {
+		t.Error("scan must not run for an idle port")
+	}
+}
+
+// BenchmarkScanUDPDropsFile measures one scan over a realistically busy
+// host table (60 sockets), matching in the last row — the worst case.
+func BenchmarkScanUDPDropsFile(b *testing.B) {
+	rows := make([]string, 0, 60)
+	for i := range 59 {
+		rows = append(rows, procUDPRow(10000+i, int64(i)))
+	}
+
+	rows = append(rows, procUDPRow(38801, 42))
+
+	const header = "   sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops"
+
+	path := filepath.Join(b.TempDir(), "udp")
+	if err := os.WriteFile(path, []byte(header+"\n"+strings.Join(rows, "\n")+"\n"), 0o600); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		drops, err := scanUDPDropsFile(path, 38801)
+		if err != nil || drops != 42 {
+			b.Fatalf("drops=%d err=%v", drops, err)
+		}
+	}
+}

--- a/internal/comms/port_channel.go
+++ b/internal/comms/port_channel.go
@@ -1,7 +1,10 @@
 package comms
 
 import (
+	"fmt"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/openmanet/openmanetd/internal/comms/codec"
 	"github.com/openmanet/openmanetd/internal/comms/control"
@@ -60,7 +63,7 @@ type McastPortState struct {
 // (see transmit.go beginTransmission/endTransmission); the malgo playback callback
 // drains it before falling through to playoutOneFrame so beeps preempt one
 // frame of jitter-buffered audio.
-type PortChannel struct {
+type PortChannel struct { //nolint:govet // fieldalignment: playbackMu must sit directly above the playback fields it guards (.claude/rules/concurrency.md); the pointer-scan-optimal layout would separate them.
 	// Decoder is this port's private Opus decoder, allocated by
 	// buildPortDecoders for every receive-capable port. It MUST NOT be
 	// shared between ports: each port's malgo playback callback runs on its
@@ -69,42 +72,172 @@ type PortChannel struct {
 	// libopus — and even serialized, interleaving two RTP streams through
 	// one stateful decoder corrupts the prediction state of both. Per-port
 	// state also keeps PLC continuity correct per stream.
-	Decoder           codec.AudioDecoder
-	RTPSess           rtp.Sender
-	PlaybackStream    device.AudioStream
+	Decoder codec.AudioDecoder
+	RTPSess rtp.Sender
+
+	// playbackMu protects the three playback lifecycle fields below. The
+	// stream pointer and running flag are written by audio
+	// init/recovery/teardown (Start goroutine, Run goroutine) and read by
+	// the RX toggle path (RPC goroutines) and beep routing, so every
+	// access goes through the lifecycle methods in this file. The mutex is
+	// deliberately held across the device Start/Stop CGO calls — that
+	// serialization is the point: malgo forbids concurrent start/stop on
+	// one device, and the calls are millisecond-scale on human-driven
+	// toggle/beep paths only, never on the audio or packet hot paths.
+	playbackMu      sync.Mutex
+	PlaybackStream  device.AudioStream
+	playbackRunning bool
+	// beepStopTimer re-sleeps a stream that queueBeep woke solely to make
+	// a PTT beep audible (no port receive-enabled). Reset on every beep so
+	// back-to-back beeps extend the window instead of truncating.
+	beepStopTimer *time.Timer
+
 	Sender            *rtp.SwappableSender
 	RTCPSend          *rtp.SwappableSender
 	Receiver          *rtp.SwappableReceiver
 	Jitter            *rtp.JitterBuffer
 	PlaybackBuffer    chan []int16
 	cfg               McastPortConfig
-	ConsecutivePLC    int
 	RxGate            control.HalfDuplexGate
+	ConsecutivePLC    int
 	PlaybackUnderruns atomic.Int64
+	RxPkts            atomic.Int64
+	RxParseErrs       atomic.Int64
+	RxLoopback        atomic.Int64
+	RxPushed          atomic.Int64
+	RxPushRejected    atomic.Int64
+	WebPoppedSkipped  atomic.Int64
+	SendEnabled       atomic.Bool
+	ReceiveEnabled    atomic.Bool
+}
 
-	// Diagnostic RX-path counters. All monotonic since startup; reporters
-	// compute deltas across windows. RxPkts is the raw "kernel handed us a
-	// packet" count from receiveLoop's ReadFromUDP; the remaining counters
-	// segment that count by what happened next. RxPushed + RxPushRejected
-	// only sum to RxPkts - RxLoopback - RxParseErrs (and only when the port
-	// is receive-enabled). Used to localize RX stutter to one specific
-	// stage of the per-port pipeline.
-	RxPkts         atomic.Int64
-	RxParseErrs    atomic.Int64
-	RxLoopback     atomic.Int64
-	RxPushed       atomic.Int64
-	RxPushRejected atomic.Int64
+// ─── Playback stream lifecycle ───────────────────────────────────────────────
+//
+// Under the P4 idle-cost design, a port's malgo playback device stays OPEN
+// for the comms run (ALSA/USB open is slow and fragile; instant RX toggling
+// is a product requirement) but its stream only RUNS while the port is
+// receive-enabled — ma_device_stop/start, no renegotiation. These methods
+// are the only sanctioned access to PlaybackStream; see the field comment
+// for the locking rationale.
 
-	// WebPoppedSkipped is bumped by webPlayoutLoop when the jitter
-	// buffer's PopReady returns skippedMissing=true (an out-of-order
-	// sequence gap wide enough that the buffer advanced the cursor past
-	// the hole). Diagnostic only; the audio path never reads this field
-	// itself. Zero on the hardware playout path, which does not use
-	// webPlayoutLoop.
-	WebPoppedSkipped atomic.Int64
+// setPlaybackStream installs (or replaces) the port's playback stream in
+// the not-running state. Called via the audio.PortSlot SetStream hook
+// during init and recovery.
+func (pc *PortChannel) setPlaybackStream(s device.AudioStream) {
+	pc.playbackMu.Lock()
+	defer pc.playbackMu.Unlock()
 
-	SendEnabled    atomic.Bool
-	ReceiveEnabled atomic.Bool
+	pc.PlaybackStream = s
+	pc.playbackRunning = false
+}
+
+// markPlaybackRunning records that the stream was started externally
+// (audio.StartHardware starts every stream itself) without touching the
+// device.
+func (pc *PortChannel) markPlaybackRunning() {
+	pc.playbackMu.Lock()
+	defer pc.playbackMu.Unlock()
+
+	pc.playbackRunning = true
+}
+
+// clearPlaybackStream detaches the stream at teardown so a late toggle or
+// beep can never call into a freed malgo device. Also run on failed init,
+// where the SetStream hook may have stored streams that BuildAudio's
+// unwind already closed.
+func (pc *PortChannel) clearPlaybackStream() {
+	pc.playbackMu.Lock()
+	defer pc.playbackMu.Unlock()
+
+	pc.PlaybackStream = nil
+	pc.playbackRunning = false
+}
+
+// playbackStreamInstalled reports whether a playback stream is attached
+// to this port (regardless of running state).
+func (pc *PortChannel) playbackStreamInstalled() bool {
+	pc.playbackMu.Lock()
+	defer pc.playbackMu.Unlock()
+
+	return pc.PlaybackStream != nil
+}
+
+// playbackIsRunning reports whether the port's playback stream is
+// currently started.
+func (pc *PortChannel) playbackIsRunning() bool {
+	pc.playbackMu.Lock()
+	defer pc.playbackMu.Unlock()
+
+	return pc.PlaybackStream != nil && pc.playbackRunning
+}
+
+// startPlayback starts the port's playback stream. Idempotent; a nil
+// stream (web mode, audio-failed mode, torn down) is a successful no-op.
+func (pc *PortChannel) startPlayback() error {
+	pc.playbackMu.Lock()
+	defer pc.playbackMu.Unlock()
+
+	if pc.PlaybackStream == nil || pc.playbackRunning {
+		return nil
+	}
+
+	if err := pc.PlaybackStream.Start(); err != nil {
+		return fmt.Errorf("start playback stream: %w", err)
+	}
+
+	pc.playbackRunning = true
+
+	return nil
+}
+
+// stopPlayback stops the port's playback stream. Idempotent; a nil stream
+// is a successful no-op.
+func (pc *PortChannel) stopPlayback() error {
+	pc.playbackMu.Lock()
+	defer pc.playbackMu.Unlock()
+
+	if pc.PlaybackStream == nil || !pc.playbackRunning {
+		return nil
+	}
+
+	if err := pc.PlaybackStream.Stop(); err != nil {
+		return fmt.Errorf("stop playback stream: %w", err)
+	}
+
+	pc.playbackRunning = false
+
+	return nil
+}
+
+// stopPlaybackIfDisabled re-sleeps the stream unless the port has been
+// receive-enabled in the meantime. Used as the beep-wake timer callback:
+// the race where RX gets enabled right after the check simply leaves the
+// stream running, which is the enabled port's correct state anyway.
+func (pc *PortChannel) stopPlaybackIfDisabled() {
+	if pc.ReceiveEnabled.Load() {
+		return
+	}
+
+	// Best-effort: a stop failure here leaves an idle stream running,
+	// which is the pre-P4 status quo, not a correctness problem.
+	_ = pc.stopPlayback()
+}
+
+// armBeepSleep schedules (or extends) the re-sleep of a beep-woken
+// stream. A single reusable timer per port: Reset on every beep so a
+// stop-beep arriving late in a previous window gets a full window of its
+// own instead of being truncated mid-tone.
+func (pc *PortChannel) armBeepSleep(d time.Duration) {
+	pc.playbackMu.Lock()
+	defer pc.playbackMu.Unlock()
+
+	if pc.beepStopTimer == nil {
+		pc.beepStopTimer = time.AfterFunc(d, pc.stopPlaybackIfDisabled)
+
+		return
+	}
+
+	pc.beepStopTimer.Reset(d)
 }
 
 // MarkRemoteRx records that a remote RTP packet has just been received on

--- a/internal/comms/port_channel_playback_test.go
+++ b/internal/comms/port_channel_playback_test.go
@@ -1,0 +1,442 @@
+package comms
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// fakeAudioStream satisfies device.AudioStream with mutex-protected call
+// counters and per-method error injection.
+type fakeAudioStream struct {
+	mu         sync.Mutex
+	startCalls int
+	stopCalls  int
+	closeCalls int
+	startErr   error
+	stopErr    error
+}
+
+func (f *fakeAudioStream) Start() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.startCalls++
+
+	return f.startErr
+}
+
+func (f *fakeAudioStream) Stop() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.stopCalls++
+
+	return f.stopErr
+}
+
+func (f *fakeAudioStream) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.closeCalls++
+
+	return nil
+}
+
+func (f *fakeAudioStream) counts() (start, stop int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.startCalls, f.stopCalls
+}
+
+// TestPortChannel_PlaybackLifecycle pins the per-port stream state machine:
+// start/stop are idempotent (never a double ma_device_start/stop), a nil
+// stream is a safe no-op, and clearing detaches the stream so a
+// post-teardown toggle can never touch a freed malgo device.
+func TestPortChannel_PlaybackLifecycle(t *testing.T) {
+	fs := &fakeAudioStream{}
+	pc := &PortChannel{}
+	pc.setPlaybackStream(fs)
+
+	if pc.playbackIsRunning() {
+		t.Error("freshly installed stream must not be marked running")
+	}
+
+	if err := pc.startPlayback(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !pc.playbackIsRunning() {
+		t.Error("startPlayback must mark the stream running")
+	}
+
+	// Idempotent: a second start must not reach the device.
+	if err := pc.startPlayback(); err != nil {
+		t.Fatal(err)
+	}
+
+	if s, _ := fs.counts(); s != 1 {
+		t.Errorf("device Start called %d times, want 1", s)
+	}
+
+	if err := pc.stopPlayback(); err != nil {
+		t.Fatal(err)
+	}
+
+	if pc.playbackIsRunning() {
+		t.Error("stopPlayback must clear the running state")
+	}
+
+	// Idempotent: a second stop must not reach the device.
+	if err := pc.stopPlayback(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, st := fs.counts(); st != 1 {
+		t.Errorf("device Stop called %d times, want 1", st)
+	}
+}
+
+func TestPortChannel_PlaybackNilStream(t *testing.T) {
+	pc := &PortChannel{}
+
+	// All no-ops without a stream (web mode, audio-failed mode).
+	if err := pc.startPlayback(); err != nil {
+		t.Errorf("startPlayback with nil stream: %v", err)
+	}
+
+	if pc.playbackIsRunning() {
+		t.Error("nil stream can never be running")
+	}
+
+	if err := pc.stopPlayback(); err != nil {
+		t.Errorf("stopPlayback with nil stream: %v", err)
+	}
+}
+
+func TestPortChannel_ClearPlaybackStream(t *testing.T) {
+	fs := &fakeAudioStream{}
+	pc := &PortChannel{}
+	pc.setPlaybackStream(fs)
+	pc.markPlaybackRunning()
+
+	pc.clearPlaybackStream()
+
+	if pc.playbackIsRunning() {
+		t.Error("cleared stream must not report running")
+	}
+
+	// A start after teardown must never reach the (freed) device.
+	if err := pc.startPlayback(); err != nil {
+		t.Fatal(err)
+	}
+
+	if s, _ := fs.counts(); s != 0 {
+		t.Errorf("device Start called %d times after clear, want 0", s)
+	}
+}
+
+func TestPortChannel_MarkPlaybackRunning(t *testing.T) {
+	fs := &fakeAudioStream{}
+	pc := &PortChannel{}
+	pc.setPlaybackStream(fs)
+
+	// StartHardware starts every stream itself; markPlaybackRunning
+	// records that fact without touching the device.
+	pc.markPlaybackRunning()
+
+	if !pc.playbackIsRunning() {
+		t.Error("markPlaybackRunning must mark the stream running")
+	}
+
+	if s, _ := fs.counts(); s != 0 {
+		t.Errorf("device Start called %d times, want 0", s)
+	}
+}
+
+func TestPortChannel_StartPlaybackError(t *testing.T) {
+	fs := &fakeAudioStream{startErr: errors.New("device gone")}
+	pc := &PortChannel{}
+	pc.setPlaybackStream(fs)
+
+	if err := pc.startPlayback(); err == nil {
+		t.Error("startPlayback must propagate the device error")
+	}
+
+	if pc.playbackIsRunning() {
+		t.Error("failed start must not mark the stream running")
+	}
+}
+
+// ─── queueBeep routing ───────────────────────────────────────────────────────
+
+// twoPortBeepRuntime builds a runtime with two receive-capable ports whose
+// playback streams are the supplied fakes (nil = no stream installed).
+func twoPortBeepRuntime(s0, s1 *fakeAudioStream) (*CommsRuntime, *PortChannel, *PortChannel) {
+	pc0 := &PortChannel{cfg: McastPortConfig{Receive: true}}
+	pc0.PlaybackBuffer = make(chan []int16, 4)
+
+	if s0 != nil {
+		pc0.setPlaybackStream(s0)
+	}
+
+	pc1 := &PortChannel{cfg: McastPortConfig{Receive: true}}
+	pc1.PlaybackBuffer = make(chan []int16, 4)
+
+	if s1 != nil {
+		pc1.setPlaybackStream(s1)
+	}
+
+	rt := &CommsRuntime{
+		Ports:           []*PortChannel{pc0, pc1},
+		BeepBufferStart: []int16{100, 200},
+		BeepBufferStop:  []int16{300, 400},
+	}
+
+	return rt, pc0, pc1
+}
+
+// TestQueueBeep_SingleRunningStream pins the single-beep contract: the
+// beep goes to exactly one port — the first with a running stream — never
+// fanned out to every port (the pre-P4 behavior played N overlapping
+// copies through dmix).
+func TestQueueBeep_SingleRunningStream(t *testing.T) {
+	s0, s1 := &fakeAudioStream{}, &fakeAudioStream{}
+	rt, pc0, pc1 := twoPortBeepRuntime(s0, s1)
+	pc0.markPlaybackRunning()
+	pc1.markPlaybackRunning()
+
+	cfg := newSilentComms()
+	cfg.queueBeep(rt, rt.BeepBufferStart)
+
+	if got := len(pc0.PlaybackBuffer); got != 1 {
+		t.Errorf("port 0 beeps queued: got %d, want 1", got)
+	}
+
+	if got := len(pc1.PlaybackBuffer); got != 0 {
+		t.Errorf("port 1 beeps queued: got %d, want 0 (single-beep contract)", got)
+	}
+}
+
+// TestQueueBeep_SkipsStoppedStream pins the running-first preference: a
+// stopped port is passed over in favor of a running one, and the stopped
+// stream is not started.
+func TestQueueBeep_SkipsStoppedStream(t *testing.T) {
+	s0, s1 := &fakeAudioStream{}, &fakeAudioStream{}
+	rt, pc0, pc1 := twoPortBeepRuntime(s0, s1)
+	// pc0 stopped (RX disabled), pc1 running.
+	pc1.markPlaybackRunning()
+
+	cfg := newSilentComms()
+	cfg.queueBeep(rt, rt.BeepBufferStart)
+
+	if got := len(pc1.PlaybackBuffer); got != 1 {
+		t.Errorf("running port 1 beeps: got %d, want 1", got)
+	}
+
+	if got := len(pc0.PlaybackBuffer); got != 0 {
+		t.Errorf("stopped port 0 beeps: got %d, want 0", got)
+	}
+
+	if s, _ := s0.counts(); s != 0 {
+		t.Errorf("stopped port 0 device started %d times, want 0 (a running port was available)", s)
+	}
+}
+
+// TestQueueBeep_WakesStreamWhenAllStopped pins the wake-for-beep path: with
+// zero receive-enabled ports (all streams stopped) the beep must still be
+// audible, so the first stream is started, the beep queued to it, and the
+// re-sleep timer armed.
+func TestQueueBeep_WakesStreamWhenAllStopped(t *testing.T) {
+	s0, s1 := &fakeAudioStream{}, &fakeAudioStream{}
+	rt, pc0, pc1 := twoPortBeepRuntime(s0, s1)
+
+	cfg := newSilentComms()
+	cfg.queueBeep(rt, rt.BeepBufferStart)
+
+	if !pc0.playbackIsRunning() {
+		t.Error("port 0 stream should be woken for the beep")
+	}
+
+	if got := len(pc0.PlaybackBuffer); got != 1 {
+		t.Errorf("port 0 beeps: got %d, want 1", got)
+	}
+
+	if pc1.playbackIsRunning() {
+		t.Error("only one stream should wake for the beep")
+	}
+
+	pc0.playbackMu.Lock()
+	armed := pc0.beepStopTimer != nil
+	pc0.playbackMu.Unlock()
+
+	if !armed {
+		t.Error("beep-woken stream must have its re-sleep timer armed")
+	}
+}
+
+// TestQueueBeep_WakeFallsThroughOnStartError pins degraded-device
+// behavior: if waking the first stream fails, the next one is tried.
+func TestQueueBeep_WakeFallsThroughOnStartError(t *testing.T) {
+	s0 := &fakeAudioStream{startErr: errors.New("device gone")}
+	s1 := &fakeAudioStream{}
+	rt, _, pc1 := twoPortBeepRuntime(s0, s1)
+
+	cfg := newSilentComms()
+	cfg.queueBeep(rt, rt.BeepBufferStart)
+
+	if !pc1.playbackIsRunning() {
+		t.Error("port 1 should be woken when port 0's device fails")
+	}
+
+	if got := len(pc1.PlaybackBuffer); got != 1 {
+		t.Errorf("port 1 beeps: got %d, want 1", got)
+	}
+}
+
+// TestQueueBeep_NoStreamFallback pins the legacy no-local-audio path (web
+// mode, audio-failed mode, unit tests): with no streams installed at all,
+// the beep still queues to the first port's buffer — harmless with no
+// consumer, and exactly what the pre-P4 code did.
+func TestQueueBeep_NoStreamFallback(t *testing.T) {
+	rt, pc0, pc1 := twoPortBeepRuntime(nil, nil)
+
+	cfg := newSilentComms()
+	cfg.queueBeep(rt, rt.BeepBufferStart)
+
+	if got := len(pc0.PlaybackBuffer); got != 1 {
+		t.Errorf("port 0 beeps: got %d, want 1", got)
+	}
+
+	if got := len(pc1.PlaybackBuffer); got != 0 {
+		t.Errorf("port 1 beeps: got %d, want 0", got)
+	}
+}
+
+// ─── startup sync + RX toggle wiring ─────────────────────────────────────────
+
+// TestMarkAndSyncPlayback pins the boot/recovery contract: StartHardware
+// starts every stream, then the comms side records that fact and re-sleeps
+// the streams of ports that are not receive-enabled — so the default
+// config (5 ports, 1 enabled) runs exactly one playback RT thread.
+func TestMarkAndSyncPlayback(t *testing.T) {
+	s0, s1 := &fakeAudioStream{}, &fakeAudioStream{}
+	rt, pc0, pc1 := twoPortBeepRuntime(s0, s1)
+	pc0.ReceiveEnabled.Store(true)
+	pc1.ReceiveEnabled.Store(false)
+
+	cfg := newSilentComms()
+	cfg.markAndSyncPlayback(rt)
+
+	if !pc0.playbackIsRunning() {
+		t.Error("enabled port 0 must stay running")
+	}
+
+	if pc1.playbackIsRunning() {
+		t.Error("disabled port 1 must be re-slept")
+	}
+
+	if _, st := s0.counts(); st != 0 {
+		t.Errorf("enabled port 0 device Stop called %d times, want 0", st)
+	}
+
+	if _, st := s1.counts(); st != 1 {
+		t.Errorf("disabled port 1 device Stop called %d times, want 1", st)
+	}
+}
+
+// TestEnableTalkGroupReceive_TogglesPlaybackStream pins the RX toggle:
+// enabling starts the port's stream, disabling stops it, and the atomic
+// flag flips in both directions.
+func TestEnableTalkGroupReceive_TogglesPlaybackStream(t *testing.T) {
+	fs := &fakeAudioStream{}
+	rt, pc0, _ := twoPortBeepRuntime(fs, nil)
+
+	svc := &Service{Cfg: newSilentComms(), Rt: rt}
+
+	if err := svc.EnableTalkGroupReceive(0, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if !pc0.ReceiveEnabled.Load() || !pc0.playbackIsRunning() {
+		t.Error("enable must set the flag and start the stream")
+	}
+
+	if err := svc.EnableTalkGroupReceive(0, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if pc0.ReceiveEnabled.Load() || pc0.playbackIsRunning() {
+		t.Error("disable must clear the flag and stop the stream")
+	}
+
+	s, st := fs.counts()
+	if s != 1 || st != 1 {
+		t.Errorf("device calls: start=%d stop=%d, want 1/1", s, st)
+	}
+}
+
+// TestEnableTalkGroupReceive_StartErrorIsNonFatal pins degraded-audio
+// behavior: a device failure on stream start is logged, not returned —
+// the RTP-side enable must still take effect (web mode and audio-failed
+// mode have no stream at all, and the audio recovery machinery owns
+// device-level failures).
+func TestEnableTalkGroupReceive_StartErrorIsNonFatal(t *testing.T) {
+	fs := &fakeAudioStream{startErr: errors.New("device gone")}
+	rt, pc0, _ := twoPortBeepRuntime(fs, nil)
+
+	svc := &Service{Cfg: newSilentComms(), Rt: rt}
+
+	if err := svc.EnableTalkGroupReceive(0, true); err != nil {
+		t.Fatalf("stream failure must not fail the RPC: %v", err)
+	}
+
+	if !pc0.ReceiveEnabled.Load() {
+		t.Error("RTP-side enable must take effect despite the stream failure")
+	}
+}
+
+// TestEnableTalkGroupReceive_DrainsStaleBeeps pins the re-enable hygiene:
+// a beep queued while the port's stream was stopped must not play when the
+// port is enabled minutes later.
+func TestEnableTalkGroupReceive_DrainsStaleBeeps(t *testing.T) {
+	fs := &fakeAudioStream{}
+	rt, pc0, _ := twoPortBeepRuntime(fs, nil)
+
+	pc0.PlaybackBuffer <- []int16{9, 9} // stale beep from a stopped period
+
+	svc := &Service{Cfg: newSilentComms(), Rt: rt}
+
+	if err := svc.EnableTalkGroupReceive(0, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := len(pc0.PlaybackBuffer); got != 0 {
+		t.Errorf("stale beeps in buffer after enable: %d, want 0", got)
+	}
+}
+
+func TestPortChannel_StopPlaybackIfDisabled(t *testing.T) {
+	fs := &fakeAudioStream{}
+	pc := &PortChannel{}
+	pc.setPlaybackStream(fs)
+	pc.markPlaybackRunning()
+
+	// RX enabled: the beep-wake sleep callback must leave it running.
+	pc.ReceiveEnabled.Store(true)
+	pc.stopPlaybackIfDisabled()
+
+	if !pc.playbackIsRunning() {
+		t.Error("stopPlaybackIfDisabled must not stop an RX-enabled port")
+	}
+
+	// RX disabled: now it stops.
+	pc.ReceiveEnabled.Store(false)
+	pc.stopPlaybackIfDisabled()
+
+	if pc.playbackIsRunning() {
+		t.Error("stopPlaybackIfDisabled must stop an RX-disabled port")
+	}
+}

--- a/internal/comms/receive.go
+++ b/internal/comms/receive.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	pionrtp "github.com/pion/rtp"
+	"github.com/rs/zerolog"
 
 	"github.com/openmanet/openmanetd/internal/comms/control"
 	"github.com/openmanet/openmanetd/internal/comms/rtp"
@@ -29,6 +30,10 @@ const maxConsecutivePLC = 10
 // popOrConceal would hand back genuine silence even though playoutOneFrame
 // is still willing to PLC.
 const concealRecentWindow = 200 * time.Millisecond
+
+// webStatDefaultInterval is the webPlayoutLoop stat-reporting period.
+// Overridable per-config for tests via CommsConfig.webStatInterval.
+const webStatDefaultInterval = 2 * time.Second
 
 const (
 	// receiveErrStreakThreshold is the number of consecutive ReadFromUDP
@@ -421,7 +426,12 @@ func (cfg *CommsConfig) webPlayoutLoop(ctx context.Context, pc *PortChannel, jit
 	// they localize where RX frames are being lost on the server side.
 	var popped, poppedSkipped int64
 
-	statTicker := time.NewTicker(2 * time.Second)
+	statInterval := webStatDefaultInterval
+	if cfg.webStatInterval > 0 {
+		statInterval = cfg.webStatInterval
+	}
+
+	statTicker := time.NewTicker(statInterval)
 	defer statTicker.Stop()
 
 	var (
@@ -502,15 +512,6 @@ func (cfg *CommsConfig) webPlayoutLoop(ctx context.Context, pc *PortChannel, jit
 			rxPushed := pc.RxPushed.Load()
 			rxPushRejected := pc.RxPushRejected.Load()
 
-			// kernel_drops is the per-socket drop counter from /proc/net/udp.
-			// readUDPSocketDrops returns -1 with no error when no row matches
-			// (e.g. on a non-Linux test host) — treat that as zero so the
-			// delta arithmetic stays sane.
-			kernelDrops, _ := readUDPSocketDrops(pc.cfg.Port)
-			if kernelDrops < 0 {
-				kernelDrops = 0
-			}
-
 			gap1 := jitter.GapRuns1.Load()
 			gap2to5 := jitter.GapRuns2to5.Load()
 			gap6to10 := jitter.GapRuns6to10.Load()
@@ -537,12 +538,31 @@ func (cfg *CommsConfig) webPlayoutLoop(ctx context.Context, pc *PortChannel, jit
 			dRxParseErrs := rxParseErrs - lastRxParseErrs
 			dRxPushed := rxPushed - lastRxPushed
 			dRxPushRejected := rxPushRejected - lastRxPushRejected
-			dKernelDrops := kernelDrops - lastKernelDrops
 
-			// Suppress idle ports: only emit a line when this port had any
-			// RX activity in the last window. Eliminates the 5-port spam
-			// where 4 inactive ports each printed an all-zero line.
-			if dRxPkts > 0 || dPopped > 0 || dPoppedSkipped > 0 || dKernelDrops > 0 {
+			// The /proc/net/udp kernel-drop scan and the stat line are
+			// debug-only telemetry, so both are gated: on RX activity in
+			// this window (per in-process counters — an idle port skips
+			// everything, eliminating the 5-port all-zero spam), and on
+			// Debug logging actually being enabled (the log line is the
+			// scan's only consumer, so scanning with Debug off is pure
+			// waste). The one signal this can miss: a port whose ONLY
+			// activity is kernel-side drops with zero successful reads —
+			// that means the receive goroutine is stalled outright, which
+			// surfaces far louder elsewhere (PLC, jitter underruns).
+			active := dRxPkts > 0 || dPopped > 0 || dPoppedSkipped > 0
+			if active && cfg.Log.GetLevel() <= zerolog.DebugLevel {
+				// kernel_drops is the per-socket drop counter from
+				// /proc/net/udp. readUDPDrops returns -1 with no error
+				// when no row matches (e.g. on a non-Linux test host) —
+				// treat that as zero so the delta arithmetic stays sane.
+				kernelDrops, _ := cfg.readUDPDrops(pc.cfg.Port)
+				if kernelDrops < 0 {
+					kernelDrops = 0
+				}
+
+				dKernelDrops := kernelDrops - lastKernelDrops
+				lastKernelDrops = kernelDrops
+
 				cfg.Log.Debug().
 					Int("port", pc.cfg.Port).
 					Int64("pkt_rx", dRxPkts).
@@ -579,7 +599,6 @@ func (cfg *CommsConfig) webPlayoutLoop(ctx context.Context, pc *PortChannel, jit
 			lastRxParseErrs = rxParseErrs
 			lastRxPushed = rxPushed
 			lastRxPushRejected = rxPushRejected
-			lastKernelDrops = kernelDrops
 			lastGap1 = gap1
 			lastGap2to5 = gap2to5
 			lastGap6to10 = gap6to10

--- a/internal/comms/receive.go
+++ b/internal/comms/receive.go
@@ -237,6 +237,15 @@ func (cfg *CommsConfig) receiveLoop(ctx context.Context, pc *PortChannel, rt *Co
 			continue
 		}
 
+		// Muted port: the packet is discarded regardless of content, so
+		// skip the RTP unmarshal (and its parse-error accounting)
+		// entirely. RxPkts and RxLoopback above still count while muted;
+		// MarkRemoteRx below must not run for muted ports (unchanged —
+		// it already sat below this check before the hoist).
+		if !pc.ReceiveEnabled.Load() {
+			continue
+		}
+
 		// Parse using pion/rtp for proper header validation.
 		if parseErr := rtp.ParseIncomingInto(buf[:n], &pkt); parseErr != nil {
 			pc.RxParseErrs.Add(1)
@@ -253,11 +262,6 @@ func (cfg *CommsConfig) receiveLoop(ctx context.Context, pc *PortChannel, rt *Co
 				Uint32("ssrc", pkt.Header.SSRC).
 				Int("payload_bytes", len(pkt.Payload)).
 				Msg("comms: RTP packet received")
-		}
-
-		// Skip payload delivery when receive is disabled at runtime.
-		if !pc.ReceiveEnabled.Load() {
-			continue
 		}
 
 		// Record the arrival time for half-duplex enforcement and prime the

--- a/internal/comms/receive_test.go
+++ b/internal/comms/receive_test.go
@@ -430,6 +430,67 @@ func TestReceiveLoop_DropsOwn4in6Packets(t *testing.T) {
 	}
 }
 
+// TestReceiveLoop_SkipsParseWhenReceiveDisabled pins the muted-port fast
+// path: a receive-disabled port must not pay the RTP unmarshal for packets
+// it will discard anyway, so parse errors are not counted while muted.
+// RxPkts still advances (the read happened) and re-enabling resumes
+// parsing.
+func TestReceiveLoop_SkipsParseWhenReceiveDisabled(t *testing.T) {
+	// Garbage packets that would fail RTP parsing if parsed.
+	garbage := []byte{0xFF, 0x00, 0x01}
+
+	var pkts []mockPacket
+	for range 3 {
+		pkts = append(pkts, mockPacket{data: garbage, src: netip.MustParseAddrPort("1.2.3.4:5004")})
+	}
+
+	reader := newMockReader(pkts...)
+	pc := &PortChannel{
+		cfg:      McastPortConfig{Send: true, Receive: true},
+		Receiver: rtp.NewSwappableReceiver(reader),
+	}
+	pc.SendEnabled.Store(true)
+	pc.ReceiveEnabled.Store(false) // muted
+	pc.PlaybackBuffer = make(chan []int16, 8)
+	rt := &CommsRuntime{Ports: []*PortChannel{pc}}
+
+	cfg := &CommsConfig{Log: zerolog.Nop(), Loopback: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		cfg.receiveLoop(ctx, pc, rt)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if reader.remaining() == 0 {
+			break
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	cancel()
+	pc.Receiver.Close()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("receiveLoop did not exit")
+	}
+
+	if got := pc.RxPkts.Load(); got != 3 {
+		t.Errorf("RxPkts: got %d, want 3 (reads still counted while muted)", got)
+	}
+
+	if got := pc.RxParseErrs.Load(); got != 0 {
+		t.Errorf("RxParseErrs: got %d, want 0 (muted ports must not parse)", got)
+	}
+}
+
 func TestReceiveLoop_DropsMalformedRTP(t *testing.T) {
 	// First packet is garbage; receiveLoop should log and continue rather than crash.
 	garbled := mockPacket{data: []byte{0xFF, 0x00, 0x01}, src: netip.MustParseAddrPort("1.2.3.4:5004")}

--- a/internal/comms/service.go
+++ b/internal/comms/service.go
@@ -93,7 +93,12 @@ func (s *Service) EnableTalkGroupSend(portIdx int, enabled bool) error {
 	return nil
 }
 
-// EnableTalkGroupReceive toggles RTP reception on the port at portIdx.
+// EnableTalkGroupReceive toggles RTP reception on the port at portIdx and
+// starts or stops the port's playback stream to match (P4: only enabled
+// ports keep a running malgo device). A device-level stream failure is
+// logged, not returned: the RTP-side enable must still take effect — web
+// mode and audio-failed mode have no stream at all, and device failures
+// are owned by the audio recovery machinery.
 func (s *Service) EnableTalkGroupReceive(portIdx int, enabled bool) error {
 	if s == nil || s.Rt == nil {
 		return ErrNotRunning
@@ -103,7 +108,35 @@ func (s *Service) EnableTalkGroupReceive(portIdx int, enabled bool) error {
 		return fmt.Errorf("comms: port index %d out of range [0, %d)", portIdx, len(s.Rt.Ports))
 	}
 
-	s.Rt.Ports[portIdx].ReceiveEnabled.Store(enabled)
+	pc := s.Rt.Ports[portIdx]
+	pc.ReceiveEnabled.Store(enabled)
+
+	if !enabled {
+		if err := pc.stopPlayback(); err != nil {
+			s.Cfg.Log.Warn().Err(err).Int("port", pc.cfg.Port).
+				Msg("comms: failed to sleep playback stream on RX disable")
+		}
+
+		return nil
+	}
+
+	// Discard beeps queued while the stream was asleep — a stale start
+	// tone from minutes ago must not play the moment the port wakes.
+	if pc.PlaybackBuffer != nil {
+	drain:
+		for {
+			select {
+			case <-pc.PlaybackBuffer:
+			default:
+				break drain
+			}
+		}
+	}
+
+	if err := pc.startPlayback(); err != nil {
+		s.Cfg.Log.Warn().Err(err).Int("port", pc.cfg.Port).
+			Msg("comms: failed to wake playback stream on RX enable")
+	}
 
 	return nil
 }

--- a/internal/comms/transmit.go
+++ b/internal/comms/transmit.go
@@ -82,6 +82,71 @@ func (cfg *CommsConfig) transmitSettleWait(rt *CommsRuntime) time.Duration {
 	return max(cfg.pttStartDelay(), beepSettle)
 }
 
+// beepWakeWindow is how long a playback stream woken solely to make a PTT
+// beep audible keeps running before it is re-slept. Sized to cover the
+// worst-case beep emergence path (ALSA ring latency + one frame + settle
+// margin, ≈150 ms on USB audio class hardware) with generous slack; the
+// timer is Reset on every beep, so a stop-beep queued late in a start-beep's
+// window always gets a full window of its own.
+const beepWakeWindow = 500 * time.Millisecond
+
+// queueBeep queues one beep frame into exactly one audible playback stream.
+// Preference order:
+//
+//  1. The first port whose stream is running (an RX-enabled port) — one
+//     clean copy of the tone. The pre-P4 code fanned the beep out to every
+//     receive-capable port, which played N overlapping copies through dmix
+//     into the same physical output.
+//  2. No stream running (zero receive-enabled ports): wake the first
+//     startable stream, queue the beep, and arm its re-sleep timer —
+//     PTT feedback must stay audible even with all monitors off.
+//  3. No streams at all (web mode, audio-failed mode): queue to the first
+//     port's buffer, matching the legacy harmless-with-no-consumer path.
+//
+// Callers must drain the playback buffers first (drainPlaybackBuffer), so
+// the buffered channel send below cannot block.
+func (cfg *CommsConfig) queueBeep(rt *CommsRuntime, beep []int16) {
+	for _, pc := range rt.Ports {
+		if pc.PlaybackBuffer != nil && pc.playbackIsRunning() {
+			pc.PlaybackBuffer <- beep
+
+			return
+		}
+	}
+
+	for _, pc := range rt.Ports {
+		if pc.PlaybackBuffer == nil {
+			continue
+		}
+
+		if err := pc.startPlayback(); err != nil {
+			cfg.Log.Warn().Err(err).Int("port", pc.cfg.Port).
+				Msg("comms: failed to wake playback stream for beep")
+
+			continue
+		}
+
+		if !pc.playbackIsRunning() {
+			// No stream installed on this port; try the next.
+			continue
+		}
+
+		pc.PlaybackBuffer <- beep
+
+		pc.armBeepSleep(beepWakeWindow)
+
+		return
+	}
+
+	for _, pc := range rt.Ports {
+		if pc.PlaybackBuffer != nil {
+			pc.PlaybackBuffer <- beep
+
+			return
+		}
+	}
+}
+
 // ─── Transmission state ───────────────────────────────────────────────────────
 
 func (cfg *CommsConfig) isBroadcasting(rt *CommsRuntime) bool {
@@ -144,12 +209,7 @@ func (cfg *CommsConfig) beginTransmission(rt *CommsRuntime) {
 
 	cfg.Log.Debug().Msg("Begin transmission: playing start tone and opening TX gate")
 	cfg.drainPlaybackBuffer(rt)
-
-	for _, pc := range rt.Ports {
-		if pc.PlaybackBuffer != nil {
-			pc.PlaybackBuffer <- rt.BeepBufferStart
-		}
-	}
+	cfg.queueBeep(rt, rt.BeepBufferStart)
 
 	// Settle window before the TX gate opens. Holds the gate closed
 	// until the start-tone beep has fully emerged from the speaker —
@@ -202,12 +262,7 @@ func (cfg *CommsConfig) endTransmission(rt *CommsRuntime) {
 	}
 
 	cfg.drainPlaybackBuffer(rt)
-
-	for _, pc := range rt.Ports {
-		if pc.PlaybackBuffer != nil {
-			pc.PlaybackBuffer <- rt.BeepBufferStop
-		}
-	}
+	cfg.queueBeep(rt, rt.BeepBufferStop)
 
 	rt.Broadcasting.Store(false)
 }

--- a/internal/comms/transmit_test.go
+++ b/internal/comms/transmit_test.go
@@ -641,10 +641,10 @@ func TestRun_AuxEvents_IgnoredWhenSourceLacksAuxInterface(t *testing.T) {
 
 // ─── Additional beginTransmission / endTransmission edge cases ────────────────
 
-// TestEndTransmission_QueuesStopBeepToAllPorts verifies that endTransmission
-// queues beepBufferStop to every configured port, mirroring the multi-port
-// start-beep behavior tested by TestBeginTransmission_BeepSentToAllPorts.
-func TestEndTransmission_QueuesStopBeepToAllPorts(t *testing.T) {
+// TestEndTransmission_QueuesStopBeepToOnePort verifies that endTransmission
+// queues beepBufferStop to exactly one port, mirroring the single-beep
+// start-beep contract tested by TestBeginTransmission_BeepSentToOnePort.
+func TestEndTransmission_QueuesStopBeepToOnePort(t *testing.T) {
 	pc0 := &PortChannel{cfg: McastPortConfig{Send: true, Receive: true}}
 	pc0.PlaybackBuffer = make(chan []int16, 16)
 
@@ -673,16 +673,18 @@ func TestEndTransmission_QueuesStopBeepToAllPorts(t *testing.T) {
 
 	cfg.endTransmission(rt)
 
-	// Both ports must have received a stop beep.
-	for i, pc := range []*PortChannel{pc0, pc1} {
-		select {
-		case frame := <-pc.PlaybackBuffer:
-			if len(frame) != 2 {
-				t.Errorf("port %d: stop-beep frame len=%d, want 2", i, len(frame))
-			}
-		default:
-			t.Errorf("port %d: expected stop beep in buffer", i)
+	// Exactly one port (the first) receives the stop beep.
+	select {
+	case frame := <-pc0.PlaybackBuffer:
+		if len(frame) != 2 {
+			t.Errorf("port 0: stop-beep frame len=%d, want 2", len(frame))
 		}
+	default:
+		t.Error("port 0: expected stop beep in buffer")
+	}
+
+	if got := len(pc1.PlaybackBuffer); got != 0 {
+		t.Errorf("port 1: beeps queued = %d, want 0 (single-beep contract)", got)
 	}
 }
 


### PR DESCRIPTION
Phase 3 of the comms hot-path review (follows #158, #159, #160): idle and steady-state cost — P4 (always-on playback devices), P8 (unconditional proc scan), P9 (parse on muted ports), P12 (NanoPTT lifecycle). Every change was developed test-first with all consumers traced before touching code; deliberate behavioral deltas are called out below and in the commit bodies.

## P9 — skip RTP parsing on receive-disabled ports

The full RTP unmarshal ran before the `ReceiveEnabled` check. Hoisted the check above the parse (after the loopback filter, so `rx_pkts`/`rx_loopback` keep counting while muted). Deltas: muted ports no longer count `rx_parse_errs` (doc row updated) or emit per-packet Trace logs; half-duplex (`MarkRemoteRx`) already sat below the check — unchanged.

## P8 — gate and stream the kernel-drop proc scan

The web-mode stat tick fully read and field-split `/proc/net/udp`(+6) every 2 s per port even with Debug off — and the Debug line is the scan's only consumer (verified: `kernel_drops` is not in the snapshot). The scan+line now require RX activity in the window AND Debug enabled; `scanUDPDropsFile` streams with `bufio.Scanner` behind a substring pre-filter (decoy-row test pins the authoritative suffix check). Characterization tests were written green against the old scanner first.

benchstat (60-row table, worst case): **14.8 µs → 6.4 µs (−57%), 29.6 KiB → 4.5 KiB (−85%), 69 → 8 allocs (−88%)**, and in production the scan now runs approximately never (Debug off).

Accepted signal loss, documented in-code: a port whose *only* activity is kernel-side drops with zero successful reads no longer logs — that state means the receive goroutine is stalled outright, which surfaces far louder elsewhere.

## P12 — NanoPTT close-on-cancel and bounded errors

Two lifecycle bugs, fixed by mirroring the in-repo OpenVLM HID pattern:
- Read errors hit `continue` unbounded: an unplugged dongle busy-spun the goroutine at 100% CPU (same bug class as Phase 0's C3). Now terminal after 3 consecutive failures; the closed event channel hands the dead device to `Run`'s existing teardown.
- `ReadOne` blocks in `read(2)` with the context checked only between reads, so cancel-while-parked leaked the goroutine **and the device fd every disable/enable cycle** (nothing ever closed the device). `context.AfterFunc` now closes the file on cancel — the evdev fd is poller-registered, so the close unblocks the read.

Key handling is byte-for-byte unchanged and now pinned for the first time. Both lifecycle fixes were watched red (channel never closed; reads unbounded).

## P4 — sleep playback streams of receive-disabled ports

Every receive-capable port ran an always-on malgo playback device: 5 talk groups, 1 enabled by default = 4 RT threads waking every 20 ms to render silence. Devices stay **open** for the run (instant RX toggle is a product requirement; ALSA/USB open is slow and fragile) but the stream only **runs** while receive-enabled — `ma_device_stop/start`, no renegotiation:

- Mutex-guarded per-port lifecycle (idempotent start/stop; teardown and failed-init detach the stream pointer, closing a pre-existing dangling-pointer hazard that was inert only because nothing read the field).
- `EnableTalkGroupReceive` starts/stops the stream with the flag and drains stale beeps on enable. Device failures are logged, not returned — the RTP-side toggle always takes effect (web mode and audio-failed mode have no stream).
- Boot **and** in-run audio recovery re-sleep disabled ports, so recovery honors toggles made while audio was down.

**Beep contract change (per review decision):** the TX beep previously fanned out to every receive-capable port, playing N overlapping copies through dmix into one speaker. It now plays through exactly one stream — the first running one — and with zero receive-enabled ports, one stream is woken just for the beep and re-slept after a 500 ms window (timer reset on every beep so a late stop-beep is never truncated). PTT feedback stays audible in every state. Note: the single copy will sound slightly quieter than the old stacked copies — that's the correct amplitude.

## Manual verification needed on target hardware

Two numbers this environment cannot produce (no ALSA hardware):
1. Idle CPU / context-switch rate with 1-of-5 ports enabled (expect ~4 fewer periodic RT wakeups).
2. RX toggle-to-first-audio latency (expect milliseconds — `ma_device_start` on an open device).
3. Audible check: PTT beep with all monitors off, and beep loudness vs. the previous release.

## Verification

- `make lint-go` — 0 issues · `make test` — pass · `make test-race` — pass · `make integration-test` — pass · `go build ./...` — clean

