### PR TITLE
feat(comms): DSCP and SO_PRIORITY marking for RTP/RTCP voice egress

### DIFF
--- a/docs/instrumentation-snapshot.md
+++ b/docs/instrumentation-snapshot.md
@@ -43,7 +43,7 @@ Every snapshot is a single JSON object with this shape:
 
 ```json
 {
-  "schema_version": "1.2.0",
+  "schema_version": "1.3.0",
   "captured_at_start": "2026-04-09T12:34:56.789012345Z",
   "captured_at_end":   "2026-04-09T12:34:56.789013101Z",
   "daemon": { ... },
@@ -58,7 +58,7 @@ Every snapshot is a single JSON object with this shape:
 
 | Field | Type | Meaning |
 |---|---|---|
-| `schema_version` | string | Semver of the envelope schema. Bump minor for additive fields, major for breaking changes. The current value is `1.2.0`. |
+| `schema_version` | string | Semver of the envelope schema. Bump minor for additive fields, major for breaking changes. The current value is `1.3.0`. |
 | `captured_at_start` | RFC3339 timestamp | Wall-clock time when the capture loop began reading counters. |
 | `captured_at_end` | RFC3339 timestamp | Wall-clock time when the capture loop finished. The difference `captured_at_end - captured_at_start` bounds the counter-read skew window; in practice this is microseconds. |
 | `daemon.version` | string | openmanetd build version. Empty until the build system populates it. |
@@ -185,6 +185,8 @@ One entry per configured multicast talk group. The slice order mirrors
 |---|---|---|
 | `address` | string | Multicast group address (e.g. `239.0.0.1`). |
 | `port` | int | UDP port. |
+| `qos_dscp` | int (0-63) | DSCP the kernel actually holds on this port's RTP sender socket, read back once at socket build time (RTCP carries the same marking). 46 = EF (default, WMM AC_VI on the mesh), 48 = CS6 (AC_VO). 0 = unmarked: `comms.dscp: 0`, a receive-only port, or a marking failure — see the QoS heuristic below. |
+| `qos_so_priority` | int | Kernel `SO_PRIORITY` read-back for the same socket. `256 + qos_dscp>>3` (e.g. 261 for EF) when fully applied — the 802.1d passthrough range that pins the WMM access class on the first hop. A value of 0-6 with a nonzero `qos_dscp` means the `SO_PRIORITY` setsockopt failed (missing CAP_NET_ADMIN) and the socket runs TOS-only; batman-adv still derives the class from the IP header on every hop. |
 | `send_enabled` | bool | Runtime toggle — if `false`, the TX path skips this talk group. |
 | `receive_enabled` | bool | Runtime toggle — if `false`, incoming RTP is not pushed into the jitter buffer. |
 | `playback_underruns` | count | Number of playback-side decode failures that had to recover via PLC (packet loss concealment). |
@@ -354,6 +356,20 @@ thumb in order and flag anything that fits.
    tight). Cross-reference `sysupgrade.capable` and
    `sysupgrade.capable_reason` to confirm the device should ever
    have been able to flash in the first place.
+14. **Voice QoS marking state.** For every Send-enabled port,
+   `comms.ports[*].qos_dscp` should equal the configured `comms.dscp`
+   (default 46) and `qos_so_priority` should equal `256 + qos_dscp>>3`
+   (261 at the default). `qos_dscp == 0` on a Send-enabled port while
+   `comms.dscp` is nonzero means the marking setsockopt failed at
+   startup — voice is riding best-effort; check daemon logs for
+   "QoS marking". A nonzero `qos_dscp` with `qos_so_priority` in 0-6
+   means TOS-only marking (`SO_PRIORITY` was refused, typically missing
+   CAP_NET_ADMIN): batman-adv hops still classify correctly from the IP
+   header, but a socket egressing a wlan directly would not. If voice
+   latency under load is the complaint and these fields read 0, fix
+   marking before tuning anything else — an unmarked voice stream
+   queues behind bulk traffic in the WMM best-effort class on every
+   hop.
 
 ## Skew note
 

--- a/example_config.yml
+++ b/example_config.yml
@@ -11,6 +11,12 @@ comms:
   enable: false
   debug: false
   controlSource: openvlm
+  # DSCP marking for outgoing voice (RTP/RTCP). 46 = EF (default): voice
+  # rides the elevated WMM video class end-to-end on the mesh. 48 = CS6:
+  # full WMM voice class (validate the radio's EDCA behavior on-air
+  # first). 0 = unmarked best-effort (pre-1.4 behavior). Out-of-range
+  # values clamp into [0, 63].
+  # dscp: 46
 # Periodic instrumentation snapshot. When enable is true the daemon writes a
 # JSON snapshot of every runtime counter/metric to snapshotDir every
 # intervalSecs. See docs/instrumentation-snapshot.md for the field reference.

--- a/internal/comms/config.go
+++ b/internal/comms/config.go
@@ -131,7 +131,13 @@ type CommsConfig struct {
 	CaptureFramesPerBuffer   int
 	CaptureLatencyMs         int
 	PacketLossPerc           int
-	PlaybackLatencyMs        int
+	// DSCP is applied to both sender sockets of every Send-enabled port
+	// at build time (IP_TOS = DSCP<<2, SO_PRIORITY = 256 + DSCP>>3). The
+	// config layer resolves absent-vs-zero before this struct is built:
+	// 0 always means "marking off" here and applyDefaults must not
+	// overwrite it, or the operator's `dscp: 0` kill switch would break.
+	DSCP              int
+	PlaybackLatencyMs int
 	// audioRecoveryInterval is the Run-loop ticker period for re-attempting
 	// hardware audio init after startup failed (OpenVLM unplugged at boot,
 	// transient ALSA error). <= 0 disables in-run recovery; applyDefaults
@@ -183,6 +189,7 @@ func NewComms(cfg CommsConfig) *CommsConfig {
 		HalfDuplexThreshold:      cfg.HalfDuplexThreshold,
 		EncoderComplexity:        cfg.EncoderComplexity,
 		PacketLossPerc:           cfg.PacketLossPerc,
+		DSCP:                     cfg.DSCP,
 		PlaybackLatencyMs:        cfg.PlaybackLatencyMs,
 		CaptureLatencyMs:         cfg.CaptureLatencyMs,
 		CaptureFramesPerBuffer:   cfg.CaptureFramesPerBuffer,

--- a/internal/comms/manager.go
+++ b/internal/comms/manager.go
@@ -69,6 +69,7 @@ func (m *CommsManager) buildCommsConfig() *CommsConfig {
 		BluetoothOutputDevice:    m.cfg.GetCommsBluetoothPttBluetoothOutputDevice(),
 		EncoderComplexity:        m.cfg.GetCommsEncoderComplexity(),
 		PacketLossPerc:           m.cfg.GetCommsPacketLossPerc(),
+		DSCP:                     m.cfg.GetCommsDSCP(),
 		PlaybackLatencyMs:        m.cfg.GetCommsPlaybackLatencyMs(),
 		CaptureLatencyMs:         m.cfg.GetCommsCaptureLatencyMs(),
 		CaptureFramesPerBuffer:   m.cfg.GetCommsCaptureFramesPerBuffer(),

--- a/internal/comms/manager_test.go
+++ b/internal/comms/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -225,4 +226,42 @@ func TestCommsManager_EnableRejectsUnknownControlSource(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown ControlSource")
 	assert.False(t, m.IsRunning(), "manager must not be running after Validate failure")
 	assert.False(t, startCalled.Load(), "start function must not be invoked when Validate fails")
+}
+
+func TestCommsManager_BuildConfigCarriesDSCP(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want int
+	}{
+		{
+			name: "default EF when key absent",
+			yaml: "comms:\n  enable: true\n",
+			want: config.DefaultCommsDSCP,
+		},
+		{
+			name: "explicit zero survives to comms config",
+			yaml: "comms:\n  enable: true\n  dscp: 0\n",
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := viper.New()
+			v.SetConfigType("yaml")
+			require.NoError(t, v.ReadConfig(strings.NewReader(tt.yaml)))
+
+			m := NewCommsManager(config.NewWithoutWatch(v), zerolog.Nop())
+
+			cc := m.buildFn()
+			assert.Equal(t, tt.want, cc.DSCP)
+
+			// The operator's `dscp: 0` kill switch must survive
+			// applyDefaults: absent-vs-zero is resolved at the config
+			// layer only, never re-defaulted here.
+			cc.applyDefaults()
+			assert.Equal(t, tt.want, cc.DSCP)
+		})
+	}
 }

--- a/internal/comms/network.go
+++ b/internal/comms/network.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/rs/zerolog"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/sys/unix"
 
@@ -74,6 +75,68 @@ func setMulticastTTL(conn *net.UDPConn, ttl int) error {
 	}
 
 	return nil
+}
+
+// setQoSMarking applies voice QoS marking to an egress UDP socket and
+// returns the kernel's resulting TOS byte and SO_PRIORITY value (both 0
+// when dscp is 0 or the socket cannot be inspected).
+//
+// IP_TOS carries the DSCP on the wire — the only part relay hops can see:
+// batman-adv re-derives skb->priority from the inner IP precedence
+// (256 + dscp>>3) when forwarding a frame. SO_PRIORITY is set to that same
+// derived value in the 256–263 802.1d passthrough range so the first hop
+// classifies without payload inspection and any direct-wlan egress is
+// covered. Deriving both from one DSCP keeps every hop in the same WMM
+// access class.
+//
+// Marking failures are logged, never fatal: unmarked voice still flows.
+// SO_PRIORITY above 6 needs CAP_NET_ADMIN (held under procd, where the
+// daemon runs as root); on EPERM the socket continues TOS-only, which
+// batman-adv still classifies from at every hop.
+func setQoSMarking(conn *net.UDPConn, dscp int, log zerolog.Logger) (tos, prio int) {
+	if dscp == 0 {
+		return 0, 0
+	}
+
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		log.Warn().Err(err).Msg("comms: QoS marking: syscall conn")
+
+		return 0, 0
+	}
+
+	if controlErr := raw.Control(func(fd uintptr) {
+		// Order matters: the kernel rewrites sk_priority to a legacy
+		// TC_PRIO_* value as a side effect of IP_TOS (rt_tos2priority), so
+		// SO_PRIORITY must be applied after IP_TOS or it would be clobbered.
+		if tosErr := unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_TOS, dscp<<2); tosErr != nil {
+			log.Warn().Err(tosErr).Int("dscp", dscp).Msg("comms: QoS marking: set IP_TOS")
+		}
+
+		if prioErr := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_PRIORITY, 256+(dscp>>3)); prioErr != nil {
+			log.Warn().Err(prioErr).Int("dscp", dscp).
+				Msg("comms: QoS marking: set SO_PRIORITY, continuing TOS-only")
+		}
+
+		// Read back what the kernel actually holds (mirroring the rx-buffer
+		// requested-vs-actual pattern) so the debug log and the port
+		// snapshot report applied state, not requested state. Read-back
+		// errors leave the zero value in place — same signal as "not set".
+		tos, _ = unix.GetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_TOS)
+		prio, _ = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_PRIORITY)
+	}); controlErr != nil {
+		log.Warn().Err(controlErr).Msg("comms: QoS marking: control")
+
+		return 0, 0
+	}
+
+	log.Debug().
+		Int("dscp", dscp).
+		Int("tos", tos).
+		Int("so_priority", prio).
+		Msg("comms: QoS marking applied")
+
+	return tos, prio
 }
 
 // readUDPDrops resolves the kernel-drop scan through the test seam,
@@ -265,6 +328,13 @@ func (cfg *CommsConfig) buildSinglePortChannel(
 			return
 		}
 
+		// The RTP sender's read-back is authoritative for the port
+		// snapshot; the TOS byte is stored as its DSCP so the snapshot
+		// matches the comms.dscp knob.
+		tos, prio := setQoSMarking(sendConn, cfg.DSCP, cfg.Log)
+		pc.QoSDSCP.Store(int32(tos >> 2))
+		pc.QoSSOPriority.Store(int32(prio))
+
 		// ── RTCP sender ────────────────────────────────────────────────
 		rtcpDst := &net.UDPAddr{IP: net.ParseIP(mpc.Address), Port: mpc.Port + 1}
 		rtcpSrc := &net.UDPAddr{IP: net.ParseIP(localIP), Port: 0}
@@ -283,6 +353,11 @@ func (cfg *CommsConfig) buildSinglePortChannel(
 
 			return
 		}
+
+		// RTCP rides the same class as RTP: it is ~1 packet per 5 s, and
+		// keeping the pair together avoids reorder-across-classes
+		// surprises. The snapshot already records the RTP read-back.
+		setQoSMarking(rtcpConn, cfg.DSCP, cfg.Log)
 
 		sess, sessErr := rtp.NewSession(ssrc, pc.Sender, pc.RTCPSend, cfg.Log)
 		if sessErr != nil {

--- a/internal/comms/network_qos_test.go
+++ b/internal/comms/network_qos_test.go
@@ -1,0 +1,182 @@
+package comms
+
+import (
+	"net"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/openmanet/openmanetd/internal/comms/rtp"
+)
+
+// newQoSTestConn opens a connected loopback UDP socket. Dialing does not
+// send any packets; the socket exists only to carry socket options.
+func newQoSTestConn(t *testing.T) *net.UDPConn {
+	t.Helper()
+
+	conn, err := net.DialUDP("udp4", nil, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+// sockoptInt reads one integer socket option straight from the kernel so
+// assertions are independent of setQoSMarking's own read-back path.
+func sockoptInt(t *testing.T, conn *net.UDPConn, level, opt int) int {
+	t.Helper()
+
+	raw, err := conn.SyscallConn()
+	require.NoError(t, err)
+
+	var (
+		val     int
+		sockErr error
+	)
+
+	require.NoError(t, raw.Control(func(fd uintptr) {
+		val, sockErr = unix.GetsockoptInt(int(fd), level, opt)
+	}))
+	require.NoError(t, sockErr)
+
+	return val
+}
+
+// canSetSOPriority probes whether this process may set SO_PRIORITY values
+// above 6 (needs CAP_NET_ADMIN). Unprivileged CI runners fail the set with
+// EPERM; the priority half of the marking tests is skipped there.
+func canSetSOPriority(t *testing.T) bool {
+	t.Helper()
+
+	conn := newQoSTestConn(t)
+
+	raw, err := conn.SyscallConn()
+	require.NoError(t, err)
+
+	var sockErr error
+
+	require.NoError(t, raw.Control(func(fd uintptr) {
+		sockErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_PRIORITY, 261)
+	}))
+
+	return sockErr == nil
+}
+
+func TestSetQoSMarking_AppliesTOSAndPriority(t *testing.T) {
+	t.Parallel()
+
+	privileged := canSetSOPriority(t)
+
+	tests := []struct {
+		name     string
+		dscp     int
+		wantTOS  int
+		wantPrio int
+	}{
+		{name: "EF maps to AC_VI", dscp: 46, wantTOS: 0xB8, wantPrio: 261},
+		{name: "CS6 maps to AC_VO", dscp: 48, wantTOS: 0xC0, wantPrio: 262},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := newQoSTestConn(t)
+
+			tos, prio := setQoSMarking(conn, tt.dscp, zerolog.Nop())
+
+			// The TOS half needs no privilege: assert unconditionally,
+			// against the kernel directly and against the read-back.
+			assert.Equal(t, tt.wantTOS, sockoptInt(t, conn, unix.IPPROTO_IP, unix.IP_TOS))
+			assert.Equal(t, tt.wantTOS, tos)
+
+			if privileged {
+				assert.Equal(t, tt.wantPrio, sockoptInt(t, conn, unix.SOL_SOCKET, unix.SO_PRIORITY))
+				assert.Equal(t, tt.wantPrio, prio)
+			} else {
+				// Without CAP_NET_ADMIN the SO_PRIORITY set fails, but the
+				// kernel still rewrites sk_priority as a side effect of
+				// IP_TOS (rt_tos2priority legacy mapping), so the exact
+				// value is kernel policy. Assert only that the read-back is
+				// truthful about whatever the kernel holds.
+				t.Log("skipping SO_PRIORITY value assertion: no CAP_NET_ADMIN in this environment")
+				assert.Equal(t, sockoptInt(t, conn, unix.SOL_SOCKET, unix.SO_PRIORITY), prio)
+			}
+		})
+	}
+}
+
+func TestSetQoSMarking_ZeroIsNoop(t *testing.T) {
+	t.Parallel()
+
+	conn := newQoSTestConn(t)
+
+	tos, prio := setQoSMarking(conn, 0, zerolog.Nop())
+
+	assert.Equal(t, 0, tos)
+	assert.Equal(t, 0, prio)
+	assert.Equal(t, 0, sockoptInt(t, conn, unix.IPPROTO_IP, unix.IP_TOS))
+	assert.Equal(t, 0, sockoptInt(t, conn, unix.SOL_SOCKET, unix.SO_PRIORITY))
+}
+
+// extractSenderConn temporarily swaps the sender's underlying writer out to
+// recover the real *net.UDPConn, then swaps it back so closePartial still
+// closes the socket.
+func extractSenderConn(t *testing.T, s *rtp.SwappableSender) *net.UDPConn {
+	t.Helper()
+
+	old := s.Swap(&mockWriter{})
+	conn, ok := old.(*net.UDPConn)
+	require.True(t, ok, "sender should wrap a *net.UDPConn")
+	s.Swap(conn)
+
+	return conn
+}
+
+func TestBuildSinglePortChannel_AppliesQoSMarking(t *testing.T) {
+	t.Parallel()
+
+	cfg := &CommsConfig{Log: zerolog.Nop(), DSCP: 46}
+	mpc := McastPortConfig{Address: "239.192.41.1", Port: 38899, Send: true}
+
+	pc, err := cfg.buildSinglePortChannel(mpc, "127.0.0.1", nil, 0x1234)
+	require.NoError(t, err)
+	t.Cleanup(pc.closePartial)
+
+	rtpConn := extractSenderConn(t, pc.Sender)
+	rtcpConn := extractSenderConn(t, pc.RTCPSend)
+
+	// Both halves of the RTP/RTCP pair must ride the same class.
+	assert.Equal(t, 0xB8, sockoptInt(t, rtpConn, unix.IPPROTO_IP, unix.IP_TOS))
+	assert.Equal(t, 0xB8, sockoptInt(t, rtcpConn, unix.IPPROTO_IP, unix.IP_TOS))
+
+	var snap PortSnapshot
+
+	pc.Snapshot(&snap)
+	assert.Equal(t, 46, snap.QoSDSCP)
+	assert.Equal(t, sockoptInt(t, rtpConn, unix.SOL_SOCKET, unix.SO_PRIORITY), snap.QoSSOPriority)
+}
+
+func TestBuildSinglePortChannel_ZeroDSCPLeavesSocketsUnmarked(t *testing.T) {
+	t.Parallel()
+
+	cfg := &CommsConfig{Log: zerolog.Nop()}
+	mpc := McastPortConfig{Address: "239.192.41.1", Port: 38897, Send: true}
+
+	pc, err := cfg.buildSinglePortChannel(mpc, "127.0.0.1", nil, 0x1234)
+	require.NoError(t, err)
+	t.Cleanup(pc.closePartial)
+
+	rtpConn := extractSenderConn(t, pc.Sender)
+	rtcpConn := extractSenderConn(t, pc.RTCPSend)
+
+	assert.Equal(t, 0, sockoptInt(t, rtpConn, unix.IPPROTO_IP, unix.IP_TOS))
+	assert.Equal(t, 0, sockoptInt(t, rtcpConn, unix.IPPROTO_IP, unix.IP_TOS))
+
+	var snap PortSnapshot
+
+	pc.Snapshot(&snap)
+	assert.Equal(t, 0, snap.QoSDSCP)
+	assert.Equal(t, 0, snap.QoSSOPriority)
+}

--- a/internal/comms/port_channel.go
+++ b/internal/comms/port_channel.go
@@ -107,8 +107,16 @@ type PortChannel struct { //nolint:govet // fieldalignment: playbackMu must sit 
 	RxPushed          atomic.Int64
 	RxPushRejected    atomic.Int64
 	WebPoppedSkipped  atomic.Int64
-	SendEnabled       atomic.Bool
-	ReceiveEnabled    atomic.Bool
+	// QoSDSCP and QoSSOPriority record the QoS marking the kernel actually
+	// holds on this port's RTP sender socket (read back after
+	// setQoSMarking at build time; RTCP carries identical marking). Both
+	// are 0 for unmarked ports (comms.dscp 0, Send=false, or marking
+	// failure). Set once before the runtime is published; atomics keep the
+	// instrumentation contract (snapshot reads are atomic-load-only).
+	QoSDSCP        atomic.Int32
+	QoSSOPriority  atomic.Int32
+	SendEnabled    atomic.Bool
+	ReceiveEnabled atomic.Bool
 }
 
 // ─── Playback stream lifecycle ───────────────────────────────────────────────

--- a/internal/comms/snapshot.go
+++ b/internal/comms/snapshot.go
@@ -32,6 +32,16 @@ type PortSnapshot struct {
 	RxGate control.HalfDuplexGateSnapshot `json:"rx_gate"`
 	// Port is the multicast UDP port.
 	Port int `json:"port"`
+	// QoSDSCP is the DSCP the kernel actually holds on this port's RTP
+	// sender socket (read back at socket build time; RTCP carries the same
+	// marking). 0 means unmarked: comms.dscp 0, a receive-only port, or a
+	// marking failure.
+	QoSDSCP int `json:"qos_dscp"`
+	// QoSSOPriority is the kernel's SO_PRIORITY read-back for the same
+	// socket. 256 + QoSDSCP>>3 when fully applied; a legacy TC_PRIO value
+	// (0-6, derived by the kernel from IP_TOS) when the SO_PRIORITY
+	// setsockopt failed and the socket is running TOS-only.
+	QoSSOPriority int `json:"qos_so_priority"`
 	// PlaybackUnderruns counts playback-side decode failures that the
 	// port audio callback had to recover from via PLC.
 	PlaybackUnderruns int64 `json:"playback_underruns"`
@@ -149,6 +159,8 @@ func (pc *PortChannel) Snapshot(dst *PortSnapshot) {
 
 	dst.Address = pc.cfg.Address
 	dst.Port = pc.cfg.Port
+	dst.QoSDSCP = int(pc.QoSDSCP.Load())
+	dst.QoSSOPriority = int(pc.QoSSOPriority.Load())
 	dst.SendEnabled = pc.SendEnabled.Load()
 	dst.ReceiveEnabled = pc.ReceiveEnabled.Load()
 	dst.PlaybackUnderruns = pc.PlaybackUnderruns.Load()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,16 @@ const (
 	// CommsPacketLossPercMax is the upper clamp for comms.packetLossPerc.
 	// Above 40, primary-frame quality degrades noticeably.
 	CommsPacketLossPercMax int = 40
+	// DefaultCommsDSCP is the DSCP applied to outgoing RTP/RTCP voice
+	// sockets (comms.dscp). 46 (EF, RFC 4594 telephony) maps to skb
+	// priority 261 → WMM AC_VI on every mesh hop under Linux's
+	// precedence-derived classification. 48 (CS6) maps to priority 262 →
+	// AC_VO — flip only after the radio's EDCA behavior is validated
+	// on-air. 0 disables marking entirely (today's best-effort behavior).
+	DefaultCommsDSCP int = 46
+	// CommsDSCPMax is the upper clamp for comms.dscp: DSCP is a 6-bit
+	// field, so 63 is the largest encodable value.
+	CommsDSCPMax int = 63
 	// DefaultCommsPlaybackLatencyMs is the playback-side device buffer depth
 	// suggested to PortAudio. The Go-side jitter buffer cannot save the
 	// audio thread from OS scheduling stalls — only the device buffer can.
@@ -200,6 +210,7 @@ type Config struct {
 	OpenMANETWebsocketPort                    int
 	CommsEncoderComplexity                    int
 	CommsPacketLossPerc                       int
+	CommsDSCP                                 int
 	CommsPlaybackLatencyMs                    int
 	CommsCaptureLatencyMs                     int
 	CommsCaptureFramesPerBuffer               int
@@ -627,6 +638,23 @@ func (c *Config) reload() { //nolint:gocognit,gocyclo
 		}
 	} else {
 		c.CommsPacketLossPerc = DefaultCommsPacketLossPerc
+	}
+
+	// Load comms DSCP marking for RTP/RTCP voice egress. IsSet-guarded so
+	// an explicit `dscp: 0` (marking off) is distinguishable from an
+	// absent key (default EF): the zero value is meaningful here, unlike
+	// the latency knobs above. Out-of-range values clamp into [0, 63].
+	if c.v.IsSet("comms.dscp") {
+		switch val := c.v.GetInt("comms.dscp"); {
+		case val < 0:
+			c.CommsDSCP = 0
+		case val > CommsDSCPMax:
+			c.CommsDSCP = CommsDSCPMax
+		default:
+			c.CommsDSCP = val
+		}
+	} else {
+		c.CommsDSCP = DefaultCommsDSCP
 	}
 
 	// Load comms playback latency. Suggested to PortAudio as the playback
@@ -1240,6 +1268,16 @@ func (c *Config) GetCommsPacketLossPerc() int {
 	defer c.mu.RUnlock()
 
 	return c.CommsPacketLossPerc
+}
+
+// GetCommsDSCP returns the DSCP for outgoing RTP/RTCP voice sockets,
+// clamped to [0, 63] by the loader. 0 means marking is disabled. See
+// DefaultCommsDSCP for the value-to-access-class mapping.
+func (c *Config) GetCommsDSCP() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.CommsDSCP
 }
 
 // GetCommsPlaybackLatencyMs returns the playback device buffer depth

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2647,3 +2647,69 @@ func TestGetSetupComplete(t *testing.T) {
 		})
 	}
 }
+
+func TestGetCommsDSCP(t *testing.T) {
+	tests := []struct {
+		name     string
+		isSet    bool
+		setValue int
+		want     int
+	}{
+		{
+			name:  "returns default 46 when not set",
+			isSet: false,
+			want:  DefaultCommsDSCP,
+		},
+		{
+			name:     "explicit zero disables marking",
+			isSet:    true,
+			setValue: 0,
+			want:     0,
+		},
+		{
+			name:     "returns configured EF value",
+			isSet:    true,
+			setValue: 46,
+			want:     46,
+		},
+		{
+			name:     "returns configured CS6 value",
+			isSet:    true,
+			setValue: 48,
+			want:     48,
+		},
+		{
+			name:     "accepts upper bound 63",
+			isSet:    true,
+			setValue: 63,
+			want:     63,
+		},
+		{
+			name:     "clamps negative to 0",
+			isSet:    true,
+			setValue: -5,
+			want:     0,
+		},
+		{
+			name:     "clamps above 63 to max",
+			isSet:    true,
+			setValue: 64,
+			want:     CommsDSCPMax,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := viper.New()
+			if tt.isSet {
+				v.Set("comms.dscp", tt.setValue)
+			}
+
+			cfg := NewWithoutWatch(v)
+
+			if got := cfg.GetCommsDSCP(); got != tt.want {
+				t.Errorf("GetCommsDSCP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/instrumentation/registry.go
+++ b/internal/instrumentation/registry.go
@@ -13,7 +13,7 @@ import (
 // minor component when adding fields, the major component when removing or
 // renaming them. Consumers (including Claude) are expected to key their
 // expectations off this value.
-const SchemaVersion = "1.2.0"
+const SchemaVersion = "1.3.0"
 
 // Snapshotter is implemented by producers that expose runtime state to the
 // snapshot framework. Refresh atomically loads the producer's current

--- a/internal/instrumentation/registry_test.go
+++ b/internal/instrumentation/registry_test.go
@@ -177,7 +177,7 @@ func TestEnvelope_JSONRoundTrip(t *testing.T) {
 
 	out, err := json.Marshal(&env)
 	require.NoError(t, err)
-	assert.Contains(t, string(out), `"schema_version":"1.2.0"`)
+	assert.Contains(t, string(out), `"schema_version":"1.3.0"`)
 	assert.Contains(t, string(out), `"count":99`)
 	assert.Contains(t, string(out), `"flag":true`)
 	assert.Contains(t, string(out), `"name":"producer"`)
@@ -196,7 +196,7 @@ func TestEnvelope_JSONRoundTrip(t *testing.T) {
 	}
 
 	require.NoError(t, json.Unmarshal(out, &decoded))
-	assert.Equal(t, "1.2.0", decoded.SchemaVersion)
+	assert.Equal(t, "1.3.0", decoded.SchemaVersion)
 	require.Len(t, decoded.Sections, 1)
 	assert.Equal(t, "producer", decoded.Sections[0].Name)
 	assert.Positive(t, decoded.Runtime.NumGoroutine)
@@ -221,7 +221,7 @@ func TestSchemaVersion_Stable(t *testing.T) {
 
 	// A drift in this constant must be deliberate — bump the copy in
 	// docs/instrumentation-snapshot.md at the same time.
-	assert.Equal(t, "1.2.0", instrumentation.SchemaVersion)
+	assert.Equal(t, "1.3.0", instrumentation.SchemaVersion)
 }
 
 // TestRegistry_CaptureSkewWindow verifies that CapturedAtEnd - CapturedAtStart

--- a/internal/instrumentation/worker_test.go
+++ b/internal/instrumentation/worker_test.go
@@ -135,7 +135,7 @@ func TestWorker_RunWritesSnapshots(t *testing.T) {
 		}
 
 		require.NoError(t, json.Unmarshal(data, &decoded))
-		assert.Equal(t, "1.2.0", decoded.SchemaVersion)
+		assert.Equal(t, "1.3.0", decoded.SchemaVersion)
 		require.Len(t, decoded.Sections, 1)
 		assert.Equal(t, "producer", decoded.Sections[0].Name)
 	}


### PR DESCRIPTION
Implements R1 (voice packet marking) from the OpenMANET voice-latency report: DSCP and socket-priority marking for all RTP/RTCP voice egress, so voice classifies into an elevated WMM access class on every mesh hop instead of riding best-effort behind bulk transfers.

## Design — one knob, derived priority

On the radio, mesh frames are batman-adv ethertype (not IP), so mac80211's DSCP classifier can't see the IP header — what classifies the frame is `skb->priority`. batman-adv preserves a socket-set priority in the 256–263 passthrough range on the first hop, but **relay hops always re-derive priority from the inner IP precedence**. Both options therefore derive from one DSCP value so every hop classifies the stream identically:

| `comms.dscp` | Wire DSCP | skb priority | AC (every hop) | Use |
|---|---|---|---|---|
| **46** (default) | EF | 261 | AC_VI | Ship default — standards-clean voice marking; leapfrogs all best-effort bulk |
| 48 | CS6 | 262 | AC_VO | Full voice class, after EDCA validation on-air |
| 0 | — | — | AC_BE | Kill switch; byte-identical to today |

- `IP_TOS = dscp<<2` — the only part relay hops can see; survives into routed segments.
- `SO_PRIORITY = 256 + dscp>>3` — classifies the first hop without payload inspection; covers direct-wlan egress.
- Marking is **set-once per socket** at build time (both senders of every Send-enabled port; RTCP rides the same class as RTP so the pair never splits). Failures log and continue — unmarked voice still flows.
- Explicit `dscp: 0` is IsSet-guarded at the config layer and `applyDefaults` never touches the field, so the operator kill switch cannot be silently re-defaulted.

**Kernel subtlety found via TDD:** Linux rewrites `sk_priority` as a side effect of `IP_TOS` (`rt_tos2priority`), so `SO_PRIORITY` must be applied *after* `IP_TOS` — reversed, the TOS set would clobber the 261. The ordering constraint is commented at the call site and the TOS-only fallback (EPERM without CAP_NET_ADMIN) is documented in the snapshot heuristic: batman-adv hops still classify from the IP header in that state.

## Observability

New per-port snapshot fields `qos_dscp` / `qos_so_priority` record the **kernel read-back** (not the requested values), so field units report their actual marking state in the instrumentation JSON. `docs/instrumentation-snapshot.md` gains the field rows plus a "Voice QoS marking state" triage heuristic; snapshot `schema_version` bumps 1.2.0 → 1.3.0 (additive). Each sender also logs applied `dscp`/`tos`/`so_priority` at Debug on startup.

## Tests

- Helper round-trip: 46 → `0xB8`, 48 → `0xC0` asserted against the kernel unconditionally; `SO_PRIORITY` 261/262 asserted when CAP_NET_ADMIN is available (probe-gated), read-back consistency otherwise.
- `dscp: 0` no-op: no setsockopt calls, TOS stays 0.
- Config: absent → 46, explicit 0 → 0, boundary 63, clamps at −5 and 64.
- Build integration: both sender sockets of a port carry the marking; snapshot fields are truthful; zero-DSCP ports stay unmarked.
- Manager: explicit 0 survives `buildCommsConfig` *and* `applyDefaults` (kill-switch pin).

## Verification

- `make lint-go` — 0 issues · `make test` — pass (36 pkgs) · `make test-race` — pass · `make integration-test` — pass
- `TestService_Snapshot_ZeroAllocSteadyState` — still allocation-free with the new fields
- `BenchmarkSwappableSenderWrite` — unchanged at 0 B/op, 0 allocs/op (no per-packet cost)

## Out of scope / follow-up

- Packages-feed `PKG_VERSION` bump + sample-config `dscp:` comment after the next tag.
- Two-node bench verification per the report: `tos 0xb8` in captures at sender bridge and relay hop, per-AC counters moving out of BE, marked A/B latency-under-load run (check `batctl mcast_flags` first — multicast flooding would understate the win).
- Consider default `dscp: 48` only after S1G EDCA/AC_VO validation on-air (config-only change).
