### PR TITLE
feat(comms): set raven selector pins and warn on ambiguous boot read

### DIFF
--- a/internal/comms/ARCHITECTURE.md
+++ b/internal/comms/ARCHITECTURE.md
@@ -106,7 +106,7 @@ internal/comms/
 │
 ├── gpio/                 Raven 5-position hardware selector (F3)
 │   ├── selector.go           Selector, Events(ctx), decodeChannel,
-│   │                         SelectorPins (PLACEHOLDER — see spec §8),
+│   │                         SelectorPins (BCM 17/27/22/24/10 → TG 1-5),
 │   │                         SelectorSnapshot, read-error breaker
 │   └── hardware.go           sole go-gpiocdev importer (cdev uAPI v2:
 │                             pull-up, both edges, kernel debounce)
@@ -1430,16 +1430,22 @@ A selection that changes nothing emits no event. The direction toggles
 
 - Raven-only (`board.GPIOSelectorSupported()`, model
   `BCM2711_RAVEN_USB`), operator-disable via `comms.gpioSelector.enable`.
-- Five lines (`SelectorPins` — **placeholders until confirmed against
-  the Raven schematic**), pull-up, active-low, both-edge kernel events
-  with kernel-side debounce (cdev uAPI v2, `go-gpiocdev`, pure Go). No
-  polling loop.
+- Five lines (`SelectorPins`, BCM GPIO 17, 27, 22, 24, 10 → talk
+  groups 1–5, confirmed against the Raven schematic 2026-09-05),
+  pull-up, active-low (switch common to GND: selected position reads
+  LOW, the rest HIGH), both-edge kernel events with kernel-side
+  debounce (cdev uAPI v2, `go-gpiocdev`, pure Go). No polling loop.
 - On each debounced edge the watcher re-reads all five lines:
   exactly one low → emit that channel; zero or several low (rotary in
   transit, wiring fault) → hold the last selection (`held_glitches`
   counter). Delivery is latest-wins depth 1. Ten consecutive read
   failures trip a breaker: channel closes, selector disabled, RPC/web
   selection unaffected.
+- The boot read is emitted first so the daemon adopts the physical
+  switch position (forwarded as `SourceInit`, no announcement). A boot
+  read with no single low line logs one warning with the raw values and
+  emits nothing — the daemon keeps its configured channel; later edge
+  glitches only bump the counter.
 - `hardware.go` is the only file that imports the library; tests run
   against the `lineGroup` fake via the `openFn` seam.
 

--- a/internal/comms/gpio/selector.go
+++ b/internal/comms/gpio/selector.go
@@ -23,13 +23,15 @@ const (
 )
 
 // SelectorPins maps selector position → GPIO line offset on the Raven's
-// BCM2711 pinctrl. Position i selects talk group i+1. Lines are
-// requested as inputs, pull-up biased, active-low (switch common to
-// GND), both-edge events.
+// BCM2711 pinctrl, confirmed against the Raven schematic 2026-09-05.
+// Values are BCM GPIO numbers, which equal gpiochip0 line offsets on
+// BCM2711. Position i selects talk group i+1: GPIO17 → 1, GPIO27 → 2,
+// GPIO22 → 3, GPIO24 → 4, GPIO10 → 5.
 //
-// PLACEHOLDER values — MUST be confirmed against the Raven schematic
-// before this branch merges (spec §8).
-var SelectorPins = [5]int{5, 6, 13, 19, 26} //nolint:gochecknoglobals // hardware constant table
+// Lines are requested as inputs with pull-up bias and both-edge events.
+// The switch common is tied to GND, so the selected position reads LOW
+// (active) and every other position reads HIGH (inactive).
+var SelectorPins = [5]int{17, 27, 22, 24, 10} //nolint:gochecknoglobals // hardware constant table
 
 // lineGroup is the consumer-side view of the requested lines.
 type lineGroup interface {
@@ -93,6 +95,7 @@ func (s *Selector) watch(ctx context.Context, lines lineGroup, edge <-chan struc
 	var (
 		last      int
 		errStreak int
+		booted    bool
 	)
 
 	read := func() bool {
@@ -110,6 +113,13 @@ func (s *Selector) watch(ctx context.Context, lines lineGroup, edge <-chan struc
 		if ch == 0 {
 			// Rotary in transit or wiring fault: hold last selection.
 			s.heldGlitches.Add(1)
+
+			if !booted {
+				// Boot has no last selection to hold, so the daemon stays
+				// on its configured channel. Say so once for field triage.
+				s.Log.Warn().Ints("values", vals).
+					Msg("gpio: no single active selector line at boot; keeping configured channel")
+			}
 
 			return true
 		}
@@ -139,6 +149,8 @@ func (s *Selector) watch(ctx context.Context, lines lineGroup, edge <-chan struc
 	if !read() { // boot onto the physical switch position
 		return
 	}
+
+	booted = true
 
 	for {
 		select {

--- a/internal/comms/gpio/selector_test.go
+++ b/internal/comms/gpio/selector_test.go
@@ -3,6 +3,7 @@ package gpio
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -237,4 +238,125 @@ func waitValuesCall(t *testing.T, fl *fakeLines) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for a Values read")
 	}
+}
+
+// TestSelectorPins_RavenMapping pins the confirmed Raven wiring: BCM
+// GPIO numbers (gpiochip0 line offsets on BCM2711), position i selecting
+// talk group i+1. A regression to the pre-schematic placeholders or a
+// duplicated line would silently break the switch in the field.
+func TestSelectorPins_RavenMapping(t *testing.T) {
+	assert.Equal(t, [5]int{17, 27, 22, 24, 10}, SelectorPins)
+
+	seen := make(map[int]struct{}, len(SelectorPins))
+
+	for i, pin := range SelectorPins {
+		assert.GreaterOrEqual(t, pin, 0, "position %d", i+1)
+		assert.LessOrEqual(t, pin, 27, "position %d: BCM2711 header exposes GPIO0-27", i+1)
+
+		_, dup := seen[pin]
+		assert.False(t, dup, "GPIO%d wired to two positions", pin)
+
+		seen[pin] = struct{}{}
+	}
+}
+
+// logCapture is a goroutine-safe zerolog sink. wrote receives one token
+// per Write so tests can wait for a log line without sleeping.
+type logCapture struct {
+	mu    sync.Mutex
+	buf   strings.Builder
+	n     int
+	wrote chan struct{}
+}
+
+func (l *logCapture) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	l.buf.Write(p)
+	l.n++
+	l.mu.Unlock()
+
+	select {
+	case l.wrote <- struct{}{}:
+	default:
+	}
+
+	return len(p), nil
+}
+
+func (l *logCapture) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.buf.String()
+}
+
+func (l *logCapture) writes() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.n
+}
+
+func (l *logCapture) wait(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-l.wrote:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a log line")
+	}
+}
+
+// TestSelector_BootGlitchWarnsOnce pins the boot-time diagnostic: when the
+// first read finds no single low line (switch between detents, harness
+// unplugged) the watcher warns once with the raw values and emits nothing,
+// so the daemon keeps its configured channel. Later in-transit glitches
+// stay silent (counter only), and a subsequent clean position still flows.
+func TestSelector_BootGlitchWarnsOnce(t *testing.T) {
+	s, fl, handler := newFakeSelector([5]int{1, 1, 1, 1, 1})
+	fl.valuesCalled = make(chan struct{}, 8)
+
+	logs := &logCapture{wrote: make(chan struct{}, 8)}
+	s.Log = zerolog.New(logs)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events, err := s.Events(ctx)
+	require.NoError(t, err)
+	waitValuesCall(t, fl)
+
+	logs.wait(t)
+	assert.Contains(t, logs.String(), `"level":"warn"`)
+	assert.Contains(t, logs.String(), "at boot")
+	assert.Contains(t, logs.String(), `"values":[1,1,1,1,1]`)
+
+	select {
+	case v := <-events:
+		t.Fatalf("boot glitch emitted %d; want no selection", v)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// A later wiring glitch is counted, not logged.
+	fl.set([5]int{0, 0, 1, 1, 1})
+	(*handler)()
+	waitValuesCall(t, fl)
+
+	select {
+	case <-logs.wrote:
+		t.Fatalf("edge glitch logged: %s", logs.String())
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// A clean position still selects.
+	fl.set([5]int{1, 1, 0, 1, 1})
+	(*handler)()
+
+	assert.Equal(t, 3, recvChannel(t, events))
+	assert.Equal(t, 1, logs.writes(), "only the boot read warns")
+
+	var snap SelectorSnapshot
+
+	s.Snapshot(&snap)
+	assert.Equal(t, int64(2), snap.HeldGlitches)
 }


### PR DESCRIPTION
## Summary

Replaces the placeholder talk group selector GPIO line offsets with the values confirmed against the Raven schematic, and adds a one-time boot diagnostic for an ambiguous switch read.

- `SelectorPins` is now `{17, 27, 22, 24, 10}` (BCM GPIO numbers, equal to `gpiochip0` line offsets on BCM2711). Position i selects talk group i+1: GPIO17 → 1, GPIO27 → 2, GPIO22 → 3, GPIO24 → 4, GPIO10 → 5.
- Wiring semantics unchanged: switch common to GND, pull-up bias requested via cdev, so the selected line reads LOW (active) and all others read HIGH (inactive). `hardware.go` is untouched.
- Boot read already adopts the physical switch position as `SourceInit` (no announcement). When that first read finds no single LOW line (switch between detents, harness unplugged), the watcher now logs one warning with the raw line values and emits nothing, so the daemon keeps its configured channel. Later in-transit glitches remain counter-only (`held_glitches`).
- `internal/comms/ARCHITECTURE.md` updated: placeholder wording removed, pin mapping and boot warning documented.

This closes the spec §8 hard gate ("P4 does not merge with placeholders").

## Tests

- `TestSelectorPins_RavenMapping`: exact pin table, all distinct, within the BCM2711 header range 0–27.
- `TestSelector_BootGlitchWarnsOnce`: boot with all lines HIGH warns once with `"values":[1,1,1,1,1]`, emits no selection; a later two-low glitch is counted but not logged; a subsequent clean position still selects; `held_glitches` ends at 2.

Both tests were written first and observed failing before the implementation.

## Verification

- `go build ./...`
- `GOARCH=mipsle` and `GOARCH=arm64` builds of `internal/comms/gpio`
- `go test -race -count=1 ./internal/comms/...` — all pass
- `golangci-lint run --timeout 5m` — 0 issues

No handler or server code touched, so the integration suite was not run. No instrumentation snapshot fields added, so `docs/instrumentation-snapshot.md` is unchanged.

## Follow-ups

- Bench verification on a Raven: step through each detent and confirm the boot position is adopted without an announcement, edge selections announce, and the boot warning appears when the switch is left between detents.
- The design spec under `docs/superpowers/` is gitignored in this repo; its §8 row was updated locally but is not part of this PR.
